### PR TITLE
feature.SLOT-47.add-validation-specific-day

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/PlanType.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/PlanType.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum PlanType {
 
-    DIA_ESPECIFICO("Día específico", "Se vence el mismo día en cada mes."),
+    DIA_ESPECIFICO("Día específico", "Se vence el mismo día en cada mes y el día de pago es del 11 al 28 inclusives."),
     PRINCIPIO_DE_MES("Principio de mes", "Se paga del 1ro al 10 de cada mes.");
 
     final String name;

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -55,12 +55,12 @@ public class StudentServiceImpl implements StudentService {
         }
 
         if (planTypeIsSpecificDay(studentDTO) && paymentDayIsInvalid(studentDTO)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El día de pago debe ser entre 1 y 31.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El día de pago debe ser entre 11 y 28.");
         }
     }
 
     private boolean paymentDayIsInvalid(CreateStudentRequest studentDTO) {
-        return studentDTO.getPaymentDay() <= 0 || studentDTO.getPaymentDay() > 31;
+        return studentDTO.getPaymentDay() <= 10 || studentDTO.getPaymentDay() > 28;
     }
 
     private boolean planTypeIsSpecificDay(CreateStudentRequest studentDTO) {


### PR DESCRIPTION
 Se limita la selección del día de pago entre 11 y 28 para "día específico", siendo que antes se limitaba del 1 al 31.