### PR TITLE
[FIX][SLOT-80]: change student filter by dni

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/StudentRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/StudentRepository.java
@@ -18,7 +18,7 @@ public interface StudentRepository extends JpaRepository<Student, UUID> {
            OR LOWER(s.lastname) LIKE LOWER(CONCAT('%', :filter, '%'))
            OR LOWER(CONCAT(s.name, ' ', s.lastname)) LIKE LOWER(CONCAT('%', :filter, '%'))
            OR LOWER(CONCAT(s.lastname, ' ', s.name)) LIKE LOWER(CONCAT('%', :filter, '%'))
-           OR s.dni LIKE CONCAT('%', :filter, '%'))
+           OR s.dni LIKE CONCAT(:filter, '%'))
     """)
     List<Student> getStudentsByUserAndNameAndLastnameAndDni(@Param("user") User user, @Param("filter") String filter);
 }


### PR DESCRIPTION
Se quita del filtro de DNI la expresión regular 'cualquier cosa' antes del filtro, de manera tal que el filtro de DNI funcione de la siguiente manera:

Si yo tengo dos DNIs registrados

42382857
28352425

Y el filtro es '42'

Solo me va a devolver el DNI '42382857' y no va a traer la coincidencia del otro DNI.