### PR TITLE
[FTR][SLOT-65]: Actualizar cronjob para la creación de cuotas

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
@@ -62,8 +62,6 @@ public abstract class MonthlyFeeProcessor {
         );
     }
 
-    public abstract boolean satisfiesTheConditionsOfThePaymentDate(Student student);
-
     public abstract PaymentPlanName getCurrentPlan();
 
     public abstract LocalDate getExpirationDate(Student student);
@@ -88,10 +86,8 @@ public abstract class MonthlyFeeProcessor {
         ));
     }
 
-
-    // TODO: Agregar condicion de fecha de pago
     private boolean shouldCreateStudentMonthlyFee(Student student) {
-        return !studentHasTheCurrentMonthlyFee(student); //&& satisfiesTheConditionsOfThePaymentDate(student);
+        return !studentHasTheCurrentMonthlyFee(student);
     }
 
 

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
@@ -6,7 +6,8 @@ import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
 import com.three_tech_solutions.slot_app.data.models.Student;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.Optional;
 
 @Slf4j
 public abstract class MonthlyFeeProcessor {
@@ -19,15 +20,10 @@ public abstract class MonthlyFeeProcessor {
      * @param newMonthlyFeeNumber Number of the new monthly fee
      * @return MonthlyFee
      */
-    public MonthlyFee createStudentMonthlyFee(Student student, int newMonthlyFeeNumber){
+    public Optional<MonthlyFee> createStudentMonthlyFee(Student student, int newMonthlyFeeNumber){
         log.info("Creando pago para el estudiante: {}", student);
         log.info("El plan es {}", getCurrentPlan());
-        return createMonthlyFee(
-                getExpirationDate(student),
-                student,
-                newMonthlyFeeNumber,
-                getStudentPlanPrice(student)
-        );
+        return shouldCreateStudentMonthlyFee(student) ? getOptionalOfMonthlyFee(student, newMonthlyFeeNumber) : Optional.empty();
     }
 
     /**
@@ -48,8 +44,12 @@ public abstract class MonthlyFeeProcessor {
         );
     }
 
+    protected int getTodayDay() {
+        return LocalDate.now().getDayOfMonth();
+    }
+
     protected MonthlyFee createMonthlyFee(
-            LocalDateTime expirationDate,
+            LocalDate expirationDate,
             Student student,
             int newMonthlyFeeNumber,
             double amount
@@ -62,11 +62,15 @@ public abstract class MonthlyFeeProcessor {
         );
     }
 
+    public abstract boolean satisfiesTheConditionsOfThePaymentDate(Student student);
+
     public abstract PaymentPlanName getCurrentPlan();
 
-    public abstract LocalDateTime getExpirationDate(Student student);
+    public abstract LocalDate getExpirationDate(Student student);
 
     public abstract double getFirstPaymentAmount(Student student, CreateStudentRequest createStudentRequest);
+
+    public abstract boolean studentDoesNotHaveCurrentMonthlyFee(Student student);
 
     protected double getStudentPlanPrice(Student student) {
         return student
@@ -74,5 +78,20 @@ public abstract class MonthlyFeeProcessor {
                 .getPlan()
                 .getCurrentPrice();
     }
+
+    private Optional<MonthlyFee> getOptionalOfMonthlyFee(Student student, int newMonthlyFeeNumber) {
+        return Optional.of(createMonthlyFee(
+                getExpirationDate(student),
+                student,
+                newMonthlyFeeNumber,
+                getStudentPlanPrice(student)
+        ));
+    }
+
+
+    private boolean shouldCreateStudentMonthlyFee(Student student) {
+        return studentDoesNotHaveCurrentMonthlyFee(student) && satisfiesTheConditionsOfThePaymentDate(student);
+    }
+
 
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
@@ -70,7 +70,7 @@ public abstract class MonthlyFeeProcessor {
 
     public abstract double getFirstPaymentAmount(Student student, CreateStudentRequest createStudentRequest);
 
-    public abstract boolean studentDoesNotHaveCurrentMonthlyFee(Student student);
+    public abstract boolean studentHasTheCurrentMonthlyFee(Student student);
 
     protected double getStudentPlanPrice(Student student) {
         return student
@@ -89,8 +89,9 @@ public abstract class MonthlyFeeProcessor {
     }
 
 
+    // TODO: Agregar condicion de fecha de pago
     private boolean shouldCreateStudentMonthlyFee(Student student) {
-        return studentDoesNotHaveCurrentMonthlyFee(student) && satisfiesTheConditionsOfThePaymentDate(student);
+        return !studentHasTheCurrentMonthlyFee(student); //&& satisfiesTheConditionsOfThePaymentDate(student);
     }
 
 

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
@@ -14,12 +14,6 @@ import java.time.YearMonth;
 public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
     public static final int BEGINNING_OF_MONTH_EXPIRATION_DATE = 10;
-    public static final int DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE = 2;
-
-    @Override
-    public boolean satisfiesTheConditionsOfThePaymentDate(Student student) {
-        return getDifferenceBetweenMaxDayOfMonthAndTodayDay() <= DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE;
-    }
 
     @Override
     public PaymentPlanName getCurrentPlan() {
@@ -67,14 +61,6 @@ public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
     private double calculateExtraClassesAmount(Double classPrice, Byte extraClasses) {
         return classPrice * extraClasses;
-    }
-
-    private int getDifferenceBetweenMaxDayOfMonthAndTodayDay() {
-        return getMaxDayOfMonth() - getTodayDay();
-    }
-
-    private int getMaxDayOfMonth() {
-        return YearMonth.now().atEndOfMonth().getDayOfMonth();
     }
 
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
@@ -7,6 +7,7 @@ import com.three_tech_solutions.slot_app.data.models.Student;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.YearMonth;
 
 @Component
@@ -27,7 +28,10 @@ public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
     @Override
     public LocalDate getExpirationDate(Student student) {
-        return LocalDate.now().withDayOfMonth(BEGINNING_OF_MONTH_EXPIRATION_DATE);
+        return itsEndOfMonth() ?
+                LocalDate.now().plusMonths(1).withDayOfMonth(BEGINNING_OF_MONTH_EXPIRATION_DATE) :
+                LocalDate.now().withDayOfMonth(BEGINNING_OF_MONTH_EXPIRATION_DATE);
+
     }
 
     @Override
@@ -37,15 +41,28 @@ public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
                     calculateExtraClassesAmount(createStudentRequest.getClassPrice(), createStudentRequest.getExtraClasses());
     }
 
+    /**
+     * Validate if student already has the monthly fee of the month.
+     * If it's end on month, processor must check the monthly fee of the next month.
+     * If it's not the end of month, processor must check the monthly fee of the current month.
+     */
     @Override
-    public boolean studentDoesNotHaveCurrentMonthlyFee(Student student) {
-//        if (getTodayDay() >= 28 && getTodayDay() <= 31) {
-//            return student.getMonthlyFees().stream().anyMatch(monthlyFee ->
-//                    monthlyFee.getExpirationDate().withMonth(LocalDate.now().getMonthValue())
-//            );
-//        }
+    public boolean studentHasTheCurrentMonthlyFee(Student student) {
+        Month monthToValidate = itsEndOfMonth() ?
+                LocalDate.now().plusMonths(1).getMonth() :
+                LocalDate.now().getMonth();
 
-        return false;
+        return student.getMonthlyFees().stream().anyMatch(monthlyFee ->
+                monthlyFee.getExpirationDate().getMonth().equals(monthToValidate)
+        );
+    }
+
+    /**
+     * This method is because BeginningOfMonthMonthlyFeeProcessor behavior
+     * depends on whether the date is the end of the month or not.
+     */
+    private boolean itsEndOfMonth() {
+        return getTodayDay() >= 28 && getTodayDay() <= 31;
     }
 
     private double calculateExtraClassesAmount(Double classPrice, Byte extraClasses) {

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
@@ -7,12 +7,18 @@ import com.three_tech_solutions.slot_app.data.models.Student;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 @Component
 public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
     public static final int BEGINNING_OF_MONTH_EXPIRATION_DATE = 10;
+    public static final int DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE = 2;
+
+    @Override
+    public boolean satisfiesTheConditionsOfThePaymentDate(Student student) {
+        return getDifferenceBetweenMaxDayOfMonthAndTodayDay() <= DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE;
+    }
 
     @Override
     public PaymentPlanName getCurrentPlan() {
@@ -20,8 +26,8 @@ public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
     }
 
     @Override
-    public LocalDateTime getExpirationDate(Student student) {
-        return LocalDateTime.now().withDayOfMonth(BEGINNING_OF_MONTH_EXPIRATION_DATE);
+    public LocalDate getExpirationDate(Student student) {
+        return LocalDate.now().withDayOfMonth(BEGINNING_OF_MONTH_EXPIRATION_DATE);
     }
 
     @Override
@@ -31,11 +37,27 @@ public class BeginningOfMonthMonthlyFeeProcessor extends MonthlyFeeProcessor {
                     calculateExtraClassesAmount(createStudentRequest.getClassPrice(), createStudentRequest.getExtraClasses());
     }
 
-    private static int getTodayDay() {
-        return LocalDate.now().getDayOfMonth();
+    @Override
+    public boolean studentDoesNotHaveCurrentMonthlyFee(Student student) {
+//        if (getTodayDay() >= 28 && getTodayDay() <= 31) {
+//            return student.getMonthlyFees().stream().anyMatch(monthlyFee ->
+//                    monthlyFee.getExpirationDate().withMonth(LocalDate.now().getMonthValue())
+//            );
+//        }
+
+        return false;
     }
 
     private double calculateExtraClassesAmount(Double classPrice, Byte extraClasses) {
         return classPrice * extraClasses;
     }
+
+    private int getDifferenceBetweenMaxDayOfMonthAndTodayDay() {
+        return getMaxDayOfMonth() - getTodayDay();
+    }
+
+    private int getMaxDayOfMonth() {
+        return YearMonth.now().atEndOfMonth().getDayOfMonth();
+    }
+
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
@@ -6,10 +6,17 @@ import com.three_tech_solutions.slot_app.data.enums.PaymentPlanName;
 import com.three_tech_solutions.slot_app.data.models.Student;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Component
 public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
+
+    public final int DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE = 2;
+
+    @Override
+    public boolean satisfiesTheConditionsOfThePaymentDate(Student student) {
+        return getDifferenceOfDaysBetweenStudentPaymentDayAndToday(student) <= DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE;
+    }
 
     @Override
     public PaymentPlanName getCurrentPlan() {
@@ -17,14 +24,28 @@ public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
     }
 
     @Override
-    public LocalDateTime getExpirationDate(Student student) {
-        return LocalDateTime.now().withDayOfMonth(
-                student.getPaymentPlan().getPaymentDay()
+    public LocalDate getExpirationDate(Student student) {
+        return LocalDate.now().withDayOfMonth(
+                getStudentPaymentDay(student)
         );
     }
 
     @Override
     public double getFirstPaymentAmount(Student student, CreateStudentRequest createStudentRequest) {
         return getStudentPlanPrice(student);
+    }
+
+    @Override
+    public boolean studentDoesNotHaveCurrentMonthlyFee(Student student) {
+        // TODO: hacer implementación correcta
+        return false;
+    }
+
+    private int getDifferenceOfDaysBetweenStudentPaymentDayAndToday(Student student) {
+        return getTodayDay() - getStudentPaymentDay(student);
+    }
+
+    private Byte getStudentPaymentDay(Student student) {
+        return student.getPaymentPlan().getPaymentDay();
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
@@ -37,8 +37,9 @@ public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
     @Override
     public boolean studentHasTheCurrentMonthlyFee(Student student) {
-        // TODO: hacer implementación correcta
-        return false;
+        return student.getMonthlyFees().stream().anyMatch(monthlyFee ->
+                monthlyFee.getExpirationDate().getMonth().equals(LocalDate.now().getMonth())
+        );
     }
 
     private int getDifferenceOfDaysBetweenStudentPaymentDayAndToday(Student student) {

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
@@ -11,13 +11,6 @@ import java.time.LocalDate;
 @Component
 public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
 
-    public final int DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE = 2;
-
-    @Override
-    public boolean satisfiesTheConditionsOfThePaymentDate(Student student) {
-        return getDifferenceOfDaysBetweenStudentPaymentDayAndToday(student) <= DAYS_DIFFERENCE_TO_CREATE_MONTHLY_FEE;
-    }
-
     @Override
     public PaymentPlanName getCurrentPlan() {
         return PaymentPlanName.SPECIFIC_DAY;
@@ -40,10 +33,6 @@ public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
         return student.getMonthlyFees().stream().anyMatch(monthlyFee ->
                 monthlyFee.getExpirationDate().getMonth().equals(LocalDate.now().getMonth())
         );
-    }
-
-    private int getDifferenceOfDaysBetweenStudentPaymentDayAndToday(Student student) {
-        return getTodayDay() - getStudentPaymentDay(student);
     }
 
     private Byte getStudentPaymentDay(Student student) {

--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/SpecificDayMonthlyFeeProcessor.java
@@ -36,7 +36,7 @@ public class SpecificDayMonthlyFeeProcessor extends MonthlyFeeProcessor {
     }
 
     @Override
-    public boolean studentDoesNotHaveCurrentMonthlyFee(Student student) {
+    public boolean studentHasTheCurrentMonthlyFee(Student student) {
         // TODO: hacer implementación correcta
         return false;
     }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/MonthlyFee.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/MonthlyFee.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,7 +17,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class MonthlyFee {
     double amount;
-    LocalDateTime expirationDate;
+    LocalDate expirationDate;
     @Column(unique = true)
     int number;
     @ManyToOne
@@ -37,7 +38,7 @@ public class MonthlyFee {
 
     public MonthlyFee(
             double amount,
-            LocalDateTime expirationDate,
+            LocalDate expirationDate,
             int number,
             Student student
     ) {

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,6 +37,7 @@ public class Plan {
     public double getCurrentPrice() {
         return this.getPrices()
                 .stream()
+                .filter(price -> price.startDate.isBefore(LocalDate.now()) && price.endDate == null)
                 .findFirst()
                 .map(Price::getAmount)
                 .orElseThrow(() -> new ResponseStatusException(INTERNAL_SERVER_ERROR, "Hubo un error al obtener los precios de los planes"));

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Student.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Student.java
@@ -60,5 +60,14 @@ public class Student {
                 .stream()
                 .anyMatch(monthlyFee -> monthlyFee.getCurrentStatus().getStatus() == MonthlyFeeStatus.OUT_OF_TIME);
     }
+
+    @Override
+    public String toString() {
+        return "Student{" +
+                "name='" + name + '\'' +
+                ", lastname='" + lastname + '\'' +
+                ", dni='" + dni + '\'' +
+                '}';
+    }
 }
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -49,7 +49,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
                 monthlyFee
                         .ifPresentOrElse(
                                 monthlyFeeRepository::save,
-                                () -> log.info("No se creó pago para el estudiante {}", student)
+                                () -> log.info("No se creó pago para el estudiante")
                         );
             } catch (Exception e) {
                 log.error("Hubo un error al crear el pago para el estudiante ", e);

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -37,7 +37,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
     private final PaymentService paymentService;
 
     @Transactional
-    @Scheduled(cron = "0 0 1 * * *")
+    @Scheduled(cron = "* * * * * *")
     @Override
     public void createStudentsMonthlyFee() {
         log.info("Iniciando proceso de creacion de pagos");

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -37,7 +37,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
     private final PaymentService paymentService;
 
     @Transactional
-    @Scheduled(cron = "* * * * * *")
+    @Scheduled(cron = "0 0 1 * * *")
     @Override
     public void createStudentsMonthlyFee() {
         log.info("Iniciando proceso de creacion de pagos");

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -49,7 +49,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
                 monthlyFee
                         .ifPresentOrElse(
                                 monthlyFeeRepository::save,
-                                () -> log.info("No se creó pago para el estudiante")
+                                () -> log.info("No se creó pago para el estudiante {}", student)
                         );
             } catch (Exception e) {
                 log.error("Hubo un error al crear el pago para el estudiante ", e);

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -20,8 +20,10 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -43,8 +45,12 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
         students.forEach(student -> {
             try {
                 MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
-                MonthlyFee monthlyFee = monthlyFeeProcessor.createStudentMonthlyFee(student, getMonthlyFeeNumber());
-                monthlyFeeRepository.save(monthlyFee);
+                Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createStudentMonthlyFee(student, getMonthlyFeeNumber());
+                monthlyFee
+                        .ifPresentOrElse(
+                                monthlyFeeRepository::save,
+                                () -> log.info("No se creó pago para el estudiante {}", student)
+                        );
             } catch (Exception e) {
                 log.error("Hubo un error al crear el pago para el estudiante ", e);
             }
@@ -77,6 +83,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
         monthlyFeeRepository.save(monthlyFee);
     }
 
+
     private int getMonthlyFeeNumber() {
         return monthlyFeeRepository.getLastMonthlyFeeNumber().orElse(0) + 1;
     }
@@ -96,7 +103,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
         MonthlyFeeStatusHistory currentStatus = monthlyFee.getCurrentStatus();
         currentStatus.setEndDate(LocalDateTime.now());
 
-        MonthlyFeeStatus newStatus = LocalDateTime.now().isAfter(monthlyFee.getExpirationDate())
+        MonthlyFeeStatus newStatus = LocalDate.now().isAfter(monthlyFee.getExpirationDate())
                 ? MonthlyFeeStatus.PAYED_OUT_OF_TIME
                 : MonthlyFeeStatus.PAYED;
 


### PR DESCRIPTION
Se modificó el cronjob para que tenga en cuenta las cuotas generadas. Además, se cambió la lógica de obtener el precio actual de un plan verificando las fechas de inicio y fin de cada precio.
La lógica planteada es la siguiente:

### Principio de mes

Para el procesador de principio de mes, se verifica si es fin de mes o no:
- Si es fin de mes (del 28 al 31 de cada mes) se verifica si existe la cuota del mes siguiente, ejemplo: si estamos entre el 28 y 31 de mayo, verificamos si ya existe la cuota de junio.
- Si no es fin de mes, se verifica la cuota del mes actual, ejemplo: si estamos en 1 de junio, verificamos la cuota de junio

### Día específico

Para el procesador del día específico, siempre se verifica si existe la cuota del mes corriente.