### PR TITLE
[FTR][SLOT-100]: Exponer endpoint para crear un turno

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
@@ -1,0 +1,17 @@
+package com.three_tech_solutions.slot_app.controllers.implementations;
+
+import com.three_tech_solutions.slot_app.controllers.interfaces.SlotController;
+import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
+import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class SlotControllerImpl implements SlotController {
+    private SlotService slotService;
+    @Override
+    public void createSlot(CreateSlotRequest request) {
+        slotService.createSlot(request);
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
@@ -1,0 +1,15 @@
+package com.three_tech_solutions.slot_app.controllers.interfaces;
+
+import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping("/slots")
+public interface SlotController {
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    void createSlot(@RequestBody CreateSlotRequest request);
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/CreateSlotRequest.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/CreateSlotRequest.java
@@ -1,0 +1,15 @@
+package com.three_tech_solutions.slot_app.controllers.requests;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record CreateSlotRequest(
+        DayOfWeek dayOfWeek,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+        UUID userId
+) {
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/AbsenceStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/AbsenceStatus.java
@@ -1,0 +1,7 @@
+package com.three_tech_solutions.slot_app.data.enums;
+
+public enum AbsenceStatus {
+    PENDING,
+    RECOVERED,
+    OUT_OF_TIME
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/SlotStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/SlotStatus.java
@@ -1,0 +1,7 @@
+package com.three_tech_solutions.slot_app.data.enums;
+
+public enum SlotStatus {
+    CREATED,
+    CANCELED,
+    DELETED
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotDetailStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotDetailStatus.java
@@ -1,0 +1,7 @@
+package com.three_tech_solutions.slot_app.data.enums;
+
+public enum SpecificSlotDetailStatus {
+    ATTENDANCE,
+    ABSENCE,
+    RECOVERED
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Absence.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Absence.java
@@ -1,0 +1,30 @@
+package com.three_tech_solutions.slot_app.data.models;
+
+import com.three_tech_solutions.slot_app.data.enums.AbsenceStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Absence {
+    private LocalDate slotDate;
+    private AbsenceStatus status;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    @ManyToOne
+    private Student student;
+    @Id
+    private UUID id;
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Absence.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Absence.java
@@ -1,9 +1,7 @@
 package com.three_tech_solutions.slot_app.data.models;
 
 import com.three_tech_solutions.slot_app.data.enums.AbsenceStatus;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +18,7 @@ import java.util.UUID;
 @Setter
 public class Absence {
     private LocalDate slotDate;
+    @Enumerated(EnumType.STRING)
     private AbsenceStatus status;
     private LocalTime startTime;
     private LocalTime endTime;

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -1,13 +1,10 @@
 package com.three_tech_solutions.slot_app.data.models;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,15 +13,26 @@ import java.util.UUID;
 @NoArgsConstructor
 @Setter
 @Getter
+@Builder
 public class Slot {
+    @Enumerated(EnumType.STRING)
     private DayOfWeek dayOfWeek;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private LocalTime startTime;
+    private LocalTime endTime;
     private byte capacity;
     @ManyToOne
     private User user;
     @OneToMany(cascade = CascadeType.ALL)
     private List<SpecificSlot> specificSlots;
     @Id
-    private UUID id;
+    private UUID id = UUID.randomUUID();
+
+    public Slot(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, byte capacity, User user, List<SpecificSlot> specificSlots) {
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.capacity = capacity;
+        this.user = user;
+        this.specificSlots = specificSlots;
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -1,0 +1,30 @@
+package com.three_tech_solutions.slot_app.data.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class Slot {
+    private DayOfWeek dayOfWeek;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private byte capacity;
+    @ManyToOne
+    private User user;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<SpecificSlot> specificSlots;
+    @Id
+    private UUID id;
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -1,9 +1,7 @@
 package com.three_tech_solutions.slot_app.data.models;
 
 import com.three_tech_solutions.slot_app.data.enums.SlotStatus;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +9,6 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,9 +22,19 @@ public class SpecificSlot {
     private byte capacity;
     private LocalTime startTime;
     private LocalTime endTime;
+    @Enumerated(EnumType.STRING)
     private SlotStatus status;
     @OneToMany
-    private List<SpecificSlotDetail> specificSlotDetails = Collections.emptyList();
+    @JoinColumn(name = "specific_slot_id")
+    private List<SpecificSlotDetail> specificSlotDetails;
     @Id
-    private UUID id;
+    private UUID id = UUID.randomUUID();
+
+    public SpecificSlot(LocalDate slotDate, byte capacity, LocalTime startTime, LocalTime endTime, SlotStatus status) {
+        this.slotDate = slotDate;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -1,0 +1,33 @@
+package com.three_tech_solutions.slot_app.data.models;
+
+import com.three_tech_solutions.slot_app.data.enums.SlotStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class SpecificSlot {
+    private LocalDate slotDate;
+    private byte capacity;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private SlotStatus status;
+    @OneToMany
+    private List<SpecificSlotDetail> specificSlotDetails = Collections.emptyList();
+    @Id
+    private UUID id;
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
@@ -15,10 +15,10 @@ import java.util.UUID;
 @Getter
 @Setter
 public class SpecificSlotDetail {
-    @Enumerated(EnumType.STRING)
-    private SpecificSlotDetailStatus status;
     @OneToOne
     private Student student;
+    @Enumerated(EnumType.STRING)
+    private SpecificSlotDetailStatus status = SpecificSlotDetailStatus.ATTENDANCE;
     @Id
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
@@ -1,9 +1,7 @@
 package com.three_tech_solutions.slot_app.data.models;
 
 import com.three_tech_solutions.slot_app.data.enums.SpecificSlotDetailStatus;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +15,7 @@ import java.util.UUID;
 @Getter
 @Setter
 public class SpecificSlotDetail {
+    @Enumerated(EnumType.STRING)
     private SpecificSlotDetailStatus status;
     @OneToOne
     private Student student;

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlotDetail.java
@@ -1,0 +1,25 @@
+package com.three_tech_solutions.slot_app.data.models;
+
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotDetailStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class SpecificSlotDetail {
+    private SpecificSlotDetailStatus status;
+    @OneToOne
+    private Student student;
+    @Id
+    private UUID id;
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Student.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Student.java
@@ -3,37 +3,44 @@ package com.three_tech_solutions.slot_app.data.models;
 import com.three_tech_solutions.slot_app.data.enums.MonthlyFeeStatus;
 import com.three_tech_solutions.slot_app.data.enums.StudentSituation;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.util.*;
 
 @Entity
-@Data
+@AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
 public class Student {
-     String name;
-     String lastname;
+     private String name;
+     private String lastname;
      @Column(unique = true)
-     String dni;
-     String phoneNumber;
-     LocalDate birthday;
-     String pathologies;
+     private String dni;
+     private String phoneNumber;
+     private LocalDate birthday;
+     private String pathologies;
      @ManyToOne
-     User user;
+     private User user;
      @OneToOne(cascade = CascadeType.ALL)
-     PaymentPlan paymentPlan;
-     boolean enabled = true;
-     LocalDate admissionDate = LocalDate.now();
+     private PaymentPlan paymentPlan;
+     private boolean enabled = true;
+     private LocalDate admissionDate = LocalDate.now();
      @OneToMany
      @JoinColumn(name = "student_id")
-     List<MonthlyFee> monthlyFees = Collections.emptyList();
+     private List<MonthlyFee> monthlyFees = Collections.emptyList();
      @OneToMany
-     @JoinColumn(name = "student_Id")
-     List<Payment> payments = Collections.emptyList();
+     @JoinColumn(name = "student_id")
+     private List<Payment> payments = Collections.emptyList();
+     @OneToMany
+     @JoinColumn(name = "student_id")
+     private List<Absence> absences = Collections.emptyList();
      @Id
-     UUID id = UUID.randomUUID();
+     private UUID id = UUID.randomUUID();
 
     public Student(String name, String lastname, String dni, String phoneNumber, LocalDate birthday, String pathologies, User user, PaymentPlan paymentPlan) {
         this.name = name;

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/User.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/User.java
@@ -31,6 +31,8 @@ public class User implements UserDetails {
     @OneToMany
     @JoinColumn(name = "user_id")
     private List<Slot> slots = Collections.emptyList();
+    @OneToOne(cascade = CascadeType.ALL)
+    private UserPreferences userPreferences = new UserPreferences();
 
     @Id
     private UUID id = UUID.randomUUID();

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/User.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/User.java
@@ -28,6 +28,9 @@ public class User implements UserDetails {
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private List<Plan> plans = Collections.emptyList();
+    @OneToMany
+    @JoinColumn(name = "user_id")
+    private List<Slot> slots = Collections.emptyList();
 
     @Id
     private UUID id = UUID.randomUUID();

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/UserPreferences.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/UserPreferences.java
@@ -1,0 +1,22 @@
+package com.three_tech_solutions.slot_app.data.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UserPreferences {
+    private byte slotCapacity = 27;
+    private long slotDurationMinutes = 60;
+    @Id
+    private UUID id = UUID.randomUUID();
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
@@ -1,0 +1,21 @@
+package com.three_tech_solutions.slot_app.data.repositories;
+
+import com.three_tech_solutions.slot_app.data.models.Slot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public interface SlotRepository extends JpaRepository<Slot, UUID> {
+    @Query("""
+        SELECT COUNT(s) > 0
+        FROM Slot s
+        WHERE :dayOfWeek = s.dayOfWeek
+        AND :time >= s.startTime
+        AND :time <  s.endTime
+    """)
+    boolean existsWithinRange(@Param("time") LocalTime time, @Param("dayOfWeek") DayOfWeek dayOfWeek);
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -23,14 +23,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public class SlotServiceImpl implements SlotService {
     private final SlotRepository slotRepository;
     private final UserService userService;
-    private final byte DEFAULT_CAPACITY;
-    private final long SLOT_DURATION_IN_HOURS;
 
     public SlotServiceImpl(SlotRepository slotRepository, UserService userService) {
         this.slotRepository = slotRepository;
         this.userService = userService;
-        this.DEFAULT_CAPACITY = 26;
-        this.SLOT_DURATION_IN_HOURS = 1;
     }
 
     @Override
@@ -46,35 +42,49 @@ public class SlotServiceImpl implements SlotService {
     }
 
     private Slot buildSlot(CreateSlotRequest request) {
+        User user = getUserByIdOrThrowException(request.userId());
         return new Slot(
                 request.dayOfWeek(),
                 request.startTime(),
-                request.startTime().plusHours(SLOT_DURATION_IN_HOURS),
-                DEFAULT_CAPACITY,
-                getUserByIdOrThrowException(request.userId()),
-                createSpecificSlots(request)
+                request.startTime().plusMinutes(user.getUserPreferences().getSlotDurationMinutes()),
+                user.getUserPreferences().getSlotCapacity(),
+                user,
+                createSpecificSlots(
+                        request,
+                        user.getUserPreferences().getSlotDurationMinutes(),
+                        user.getUserPreferences().getSlotCapacity()
+                )
         );
     }
 
-    private List<SpecificSlot> createSpecificSlots(CreateSlotRequest request) {
+    private List<SpecificSlot> createSpecificSlots(
+            CreateSlotRequest request,
+            long slotDurationMinutes,
+            byte slotCapacity
+    ) {
         List<SpecificSlot> specificSlots = new ArrayList<>();
         LocalDate date = getNextDateOfDayOfWeek(request);
         LocalDate endDate = date.plusMonths(2);
 
         while (date.isBefore(endDate) || date.isEqual(endDate)) {
-            specificSlots.add(buildSpecificSlot(request, date));
+            specificSlots.add(buildSpecificSlot(request, date, slotCapacity, slotDurationMinutes));
             date = date.plusWeeks(1);
         }
 
         return specificSlots;
     }
 
-    private SpecificSlot buildSpecificSlot(CreateSlotRequest request, LocalDate startDate) {
+    private SpecificSlot buildSpecificSlot(
+            CreateSlotRequest request,
+            LocalDate startDate,
+            byte slotCapacity,
+            long slotDurationMinutes
+    ) {
         return new SpecificSlot(
                 startDate,
-                DEFAULT_CAPACITY,
+                slotCapacity,
                 request.startTime(),
-                request.startTime().plusHours(SLOT_DURATION_IN_HOURS),
+                request.startTime().plusMinutes(slotDurationMinutes),
                 SlotStatus.CREATED
         );
     }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -1,0 +1,89 @@
+package com.three_tech_solutions.slot_app.services.implementations;
+
+import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
+import com.three_tech_solutions.slot_app.data.enums.SlotStatus;
+import com.three_tech_solutions.slot_app.data.models.Slot;
+import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
+import com.three_tech_solutions.slot_app.data.models.User;
+import com.three_tech_solutions.slot_app.data.repositories.SlotRepository;
+import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
+import com.three_tech_solutions.slot_app.services.interfaces.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Service
+public class SlotServiceImpl implements SlotService {
+    private final SlotRepository slotRepository;
+    private final UserService userService;
+    private final byte DEFAULT_CAPACITY;
+    private final long SLOT_DURATION_IN_HOURS;
+
+    public SlotServiceImpl(SlotRepository slotRepository, UserService userService) {
+        this.slotRepository = slotRepository;
+        this.userService = userService;
+        this.DEFAULT_CAPACITY = 26;
+        this.SLOT_DURATION_IN_HOURS = 1;
+    }
+
+    @Override
+    public void createSlot(CreateSlotRequest request) {
+        if(timeSlotIsAlreadyUsed(request))
+            throw new ResponseStatusException(BAD_REQUEST, "Ya existe un turno que coincide con el día y horario ingresado");
+        
+        slotRepository.save(buildSlot(request));
+    }
+
+    private boolean timeSlotIsAlreadyUsed(CreateSlotRequest request) {
+        return slotRepository.existsWithinRange(request.startTime(), request.dayOfWeek());
+    }
+
+    private Slot buildSlot(CreateSlotRequest request) {
+        return new Slot(
+                request.dayOfWeek(),
+                request.startTime(),
+                request.startTime().plusHours(SLOT_DURATION_IN_HOURS),
+                DEFAULT_CAPACITY,
+                getUserByIdOrThrowException(request.userId()),
+                createSpecificSlots(request)
+        );
+    }
+
+    private List<SpecificSlot> createSpecificSlots(CreateSlotRequest request) {
+        List<SpecificSlot> specificSlots = new ArrayList<>();
+        LocalDate date = getNextDateOfDayOfWeek(request);
+        LocalDate endDate = date.plusMonths(2);
+
+        while (date.isBefore(endDate) || date.isEqual(endDate)) {
+            specificSlots.add(buildSpecificSlot(request, date));
+            date = date.plusWeeks(1);
+        }
+
+        return specificSlots;
+    }
+
+    private SpecificSlot buildSpecificSlot(CreateSlotRequest request, LocalDate startDate) {
+        return new SpecificSlot(
+                startDate,
+                DEFAULT_CAPACITY,
+                request.startTime(),
+                request.startTime().plusHours(SLOT_DURATION_IN_HOURS),
+                SlotStatus.CREATED
+        );
+    }
+
+    private static LocalDate getNextDateOfDayOfWeek(CreateSlotRequest request) {
+        return LocalDate.now().with(TemporalAdjusters.next(request.dayOfWeek()));
+    }
+
+    private User getUserByIdOrThrowException(UUID userId) {
+        return userService.getUserByIdOrThrowException(userId);
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -1,0 +1,7 @@
+package com.three_tech_solutions.slot_app.services.interfaces;
+
+import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
+
+public interface SlotService {
+    void createSlot(CreateSlotRequest request);
+}


### PR DESCRIPTION
Al crear los turnos, se genera el objeto de la entidad "Slot" junto a todos los turnos específicos para cada día de la semana por los próximos dos meses. Se valida que no coincida el tiempo ingresado con un turno ya registrado previamente:

Si existiese un turno de 09:00 a 10:00:

* time = 08:00 --> Se puede crear el turno
* time = 09:00 --> No se puede crear el turno
* time = 09.59 --> No se puede crear el turno
* time = 10:00 --> Se puede crear el turno

Además, se crearon todas las entidades acorde al diseño realizado para la **Gestión de calendario** y se agregaron las preferencias de usuario, donde se tiene almacenado la duración del turno y la cantidad de cupos disponibles para los turnos

## Se crea el turno
<img width="1073" height="464" alt="image" src="https://github.com/user-attachments/assets/c677e770-a8e4-433f-9d24-8c8c5d2ce7f1" />

## Se intenta crear el turno con el mismo horario
<img width="1084" height="620" alt="image" src="https://github.com/user-attachments/assets/e0388f78-d181-4abf-9b0a-2980c2928081" />

## Se crea un turno con una hora de diferencia
<img width="1074" height="539" alt="image" src="https://github.com/user-attachments/assets/84a7e56b-9bc0-4a1b-b8be-c9365258d0f9" />

## Se crea un turno con el mismo horario usado previamente, pero diferente dia
<img width="1078" height="551" alt="image" src="https://github.com/user-attachments/assets/ffa0f782-7abb-4312-848d-4fabcc0abc94" />

## Registros en la base de datos de los turnos específicos 
<img width="719" height="687" alt="image" src="https://github.com/user-attachments/assets/42fba9dc-52e5-47e1-a5a4-7b6266ba3557" />
