### PR TITLE
[FTR][SLOT-114] Add paymentId to StudentMonthlyFeeResponse and MonthlyFeeMapper

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/StudentMonthlyFeeResponse.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/StudentMonthlyFeeResponse.java
@@ -13,5 +13,6 @@ public record StudentMonthlyFeeResponse(
         @JsonFormat(pattern = "dd/MM/yyyy")
         LocalDate expirationDate,
         double amount,
-        MonthlyFeeStatus status
+        MonthlyFeeStatus status,
+        UUID paymentId
 ) {}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/mappers/MonthlyFeeMapper.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/mappers/MonthlyFeeMapper.java
@@ -11,7 +11,8 @@ public class MonthlyFeeMapper {
                 monthlyFee.getExpirationDate().getMonth().name(),
                 monthlyFee.getExpirationDate(),
                 monthlyFee.getAmount(),
-                monthlyFee.getCurrentStatus()
+                monthlyFee.getCurrentStatus(),
+                monthlyFee.getPayment() != null ? monthlyFee.getPayment().getId() : null
         );
     }
 }


### PR DESCRIPTION
Agregué paymentId para poder acceder a la información del pago desde el frontend mediante StudentMonthlyFeeResponse para este modal:
<img width="594" height="525" alt="image" src="https://github.com/user-attachments/assets/a6f08878-0c16-4f1b-8a7d-0b9d3cfe4ab2" />
