### PR TITLE
[FIX][SLOT-128] add fix to create an update price of plan

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/MonthlyFeeProcessor.java
@@ -86,7 +86,8 @@ public abstract class MonthlyFeeProcessor {
         return student
                 .getPaymentPlan()
                 .getPlan()
-                .getCurrentPrice();
+                .getCurrentPrice()
+                .getAmount();
     }
 
     private Optional<MonthlyFee> getOptionalOfMonthlyFee(Student student, int newMonthlyFeeNumber) {

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/PlanControllerImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/PlanControllerImpl.java
@@ -6,6 +6,8 @@ import com.three_tech_solutions.slot_app.controllers.requests.UpdatePriceRequest
 import com.three_tech_solutions.slot_app.controllers.responses.PlanResponse;
 import com.three_tech_solutions.slot_app.services.implementations.PlanServiceImpl;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/CreatePlanRequest.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/CreatePlanRequest.java
@@ -1,13 +1,11 @@
 package com.three_tech_solutions.slot_app.controllers.requests;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
 public record CreatePlanRequest(
         String name,
         Byte numberOfDays,
         double amount,
-        LocalDate startDate,
         UUID userId
 ) {
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/UpdatePriceRequest.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/requests/UpdatePriceRequest.java
@@ -1,7 +1,9 @@
 package com.three_tech_solutions.slot_app.controllers.requests;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import org.aspectj.lang.annotation.After;
 
 import java.time.LocalDate;
 
@@ -11,5 +13,6 @@ public record UpdatePriceRequest(
     @Min(value = 0, message = "El monto debe ser mayor o igual a 0")
     Double amount,
     @NotNull(message = "Debe ingresar la fecha de vigencia del nuevo precio")
+    @FutureOrPresent(message = "Se debe ingresar una fecha igual o superior a la actual.")
     LocalDate startDate
 ){}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,7 +21,7 @@ public class Plan {
     byte numberOfDays;
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "plan_id")
-    @OrderBy("startDate DESC")
+    @OrderBy("createdAt DESC")
     List<Price> prices;
     @ManyToOne
     User user;
@@ -34,12 +35,15 @@ public class Plan {
         this.user = user;
     }
 
-    public double getCurrentPrice() {
+    public Price getCurrentPrice() {
         return this.getPrices()
                 .stream()
-                .filter(price -> price.startDate.isBefore(LocalDate.now()) && price.endDate == null)
+                .filter(price -> priceStartDateIsBeforeOrEqualThanToday(price, LocalDate.now()) && price.endDate == null)
                 .findFirst()
-                .map(Price::getAmount)
                 .orElseThrow(() -> new ResponseStatusException(INTERNAL_SERVER_ERROR, "Hubo un error al obtener los precios de los planes"));
+    }
+
+    private static boolean priceStartDateIsBeforeOrEqualThanToday(Price price, LocalDate today) {
+        return price.startDate.isBefore(today) || price.startDate.isEqual(today);
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Price.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Price.java
@@ -2,10 +2,12 @@ package com.three_tech_solutions.slot_app.data.models;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OrderBy;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -15,6 +17,7 @@ public class Price {
     double amount;
     LocalDate startDate;
     LocalDate endDate = null;
+    LocalDateTime createdAt = LocalDateTime.now();
     @Id
     UUID id = UUID.randomUUID();
 

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/PlanRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/PlanRepository.java
@@ -3,7 +3,9 @@ package com.three_tech_solutions.slot_app.data.repositories;
 import com.three_tech_solutions.slot_app.data.models.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface PlanRepository extends JpaRepository<Plan, UUID> {
+    Optional<Plan> findByIdOrderByPrices_createdAtDesc(UUID planId);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,15 +37,6 @@ public class PlanServiceImpl implements PlanService {
         }
     }
 
-    private PlanResponse buildPlanResponse(Plan plan) {
-        return new PlanResponse(
-                plan.getId(),
-                plan.getName(),
-                plan.getCurrentPrice(),
-                plan.getNumberOfDays()
-        );
-    }
-
     @Override
     public Plan getPlanByIdOrThrowException(UUID planId) {
         return this.planRepository.findById(planId)
@@ -54,10 +46,18 @@ public class PlanServiceImpl implements PlanService {
     @Override
     public PlanResponse updatePrice(UUID planId, UpdatePriceRequest updatePriceRequest) {
         Plan plan = this.getPlanByIdOrThrowException(planId);
-        plan.getPrices().add(new Price(updatePriceRequest.amount(), updatePriceRequest.startDate()));
+        setEndDateToCurrentPriceIfNecessary(updatePriceRequest, plan);
+        plan.getPrices().addFirst(new Price(updatePriceRequest.amount(), updatePriceRequest.startDate()));
         return buildPlanResponse(
                 this.planRepository.save(plan)
         );
+    }
+
+    private static void setEndDateToCurrentPriceIfNecessary(UpdatePriceRequest updatePriceRequest, Plan plan) {
+        LocalDate today = LocalDate.now();
+        if (updatePriceRequest.startDate().isBefore(today) || updatePriceRequest.startDate().isEqual(today)) {
+            plan.getCurrentPrice().setEndDate(today);
+        }
     }
 
     private Plan createAndSavePlan(CreatePlanRequest createPlanRequest) {
@@ -75,11 +75,20 @@ public class PlanServiceImpl implements PlanService {
         );
     }
 
+    private PlanResponse buildPlanResponse(Plan plan) {
+        return new PlanResponse(
+                plan.getId(),
+                plan.getName(),
+                plan.getCurrentPrice().getAmount(),
+                plan.getNumberOfDays()
+        );
+    }
+
     private static List<Price> createListOfPrices(CreatePlanRequest createPlanRequest) {
         return List.of(
                 new Price(
                         createPlanRequest.amount(),
-                        createPlanRequest.startDate()
+                        LocalDate.now()
                 )
         );
     }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
@@ -74,7 +74,7 @@ public class UserServiceImpl implements UserService {
                                 .map(plan -> new PlanResponse(
                                         plan.getId(),
                                         plan.getName(),
-                                        plan.getCurrentPrice(),
+                                        plan.getCurrentPrice().getAmount(),
                                         plan.getNumberOfDays()
                                 ))
                                 .toList()


### PR DESCRIPTION
- Fix al obtener los precios del plan: ahora verificamos que la fecha de vigencia del precio sea también igual a la fecha actual.
- Fix al actualizar el precio: se agregó una validación para que si la fecha de vigencia del nuevo precio es igual a la fecha de hoy, se setea la fecha de fin del precio vigente. Además, se agregó una validación a nivel DTO para que las fechas de vigencia del nuevo precio solo sean igual o superior a la fecha actual 
- Modificación al crear el plan: ahora no se pide más la fecha de vigencia del precio del plan, sino que se toma por defecto la fecha actual en la que se crea el plan.