### PR TITLE
Feature.slot 118.delete slot endpoint

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
@@ -6,6 +6,8 @@ import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @AllArgsConstructor
 public class SlotControllerImpl implements SlotController {
@@ -13,5 +15,10 @@ public class SlotControllerImpl implements SlotController {
     @Override
     public void createSlot(CreateSlotRequest request) {
         slotService.createSlot(request);
+    }
+
+    @Override
+    public void deleteSlot(UUID id) {
+        slotService.deleteSlot(id);
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SlotControllerImpl.java
@@ -18,7 +18,7 @@ public class SlotControllerImpl implements SlotController {
     }
 
     @Override
-    public void deleteSlot(UUID id) {
-        slotService.deleteSlot(id);
+    public void deleteSlot(UUID slotId) {
+        slotService.deleteSlot(slotId);
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
@@ -2,14 +2,16 @@ package com.three_tech_solutions.slot_app.controllers.interfaces;
 
 import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RequestMapping("/slots")
 public interface SlotController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     void createSlot(@RequestBody CreateSlotRequest request);
+
+    @DeleteMapping("/{slotId}")
+    void deleteSlot(@PathVariable UUID slotId);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SlotController.java
@@ -13,5 +13,6 @@ public interface SlotController {
     void createSlot(@RequestBody CreateSlotRequest request);
 
     @DeleteMapping("/{slotId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     void deleteSlot(@PathVariable UUID slotId);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
@@ -1,6 +1,6 @@
 package com.three_tech_solutions.slot_app.data.enums;
 
-public enum SlotStatus {
+public enum SpecificSlotStatus {
     CREATED,
     CANCELED,
     DELETED

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -21,7 +21,7 @@ public class Slot {
     private byte capacity;
     @ManyToOne
     private User user;
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SpecificSlot> specificSlots = new ArrayList<>();
     @ManyToMany
     private Set<Student> students = new HashSet<>();

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -22,9 +22,10 @@ public class Slot {
     @ManyToOne
     private User user;
     @OneToMany(cascade = CascadeType.ALL)
-    private List<SpecificSlot> specificSlots;
+    private List<SpecificSlot> specificSlots = new ArrayList<>();
     @ManyToMany
     private Set<Student> students = new HashSet<>();
+    private boolean active = true;
     @Id
     private UUID id = UUID.randomUUID();
 

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -1,6 +1,6 @@
 package com.three_tech_solutions.slot_app.data.models;
 
-import com.three_tech_solutions.slot_app.data.enums.SlotStatus;
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,14 +23,14 @@ public class SpecificSlot {
     private LocalTime startTime;
     private LocalTime endTime;
     @Enumerated(EnumType.STRING)
-    private SlotStatus status;
+    private SpecificSlotStatus status;
     @OneToMany
     @JoinColumn(name = "specific_slot_id")
     private List<SpecificSlotDetail> specificSlotDetails;
     @Id
     private UUID id = UUID.randomUUID();
 
-    public SpecificSlot(LocalDate slotDate, byte capacity, LocalTime startTime, LocalTime endTime, SlotStatus status) {
+    public SpecificSlot(LocalDate slotDate, byte capacity, LocalTime startTime, LocalTime endTime, SpecificSlotStatus status) {
         this.slotDate = slotDate;
         this.capacity = capacity;
         this.startTime = startTime;

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
@@ -27,5 +27,5 @@ public interface SlotRepository extends JpaRepository<Slot, UUID> {
             AND s.dayOfWeek = :dayOfWeek
             ORDER BY s.startTime ASC
             """)
-    List<Slot> findAllByUserIdAndDayOfWeekOrdered(User user, DayOfWeek dayOfWeek);
+    List<Slot> findAllByUserIdAndDayOfWeekAndActiveTrueOrdered(User user, DayOfWeek dayOfWeek);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
@@ -21,11 +21,5 @@ public interface SlotRepository extends JpaRepository<Slot, UUID> {
     """)
     boolean existsWithinRange(@Param("time") LocalTime time, @Param("dayOfWeek") DayOfWeek dayOfWeek);
 
-    @Query("""
-            SELECT s FROM Slot s
-            WHERE s.user = :user
-            AND s.dayOfWeek = :dayOfWeek
-            ORDER BY s.startTime ASC
-            """)
-    List<Slot> findAllByUserIdAndDayOfWeekAndActiveTrueOrdered(User user, DayOfWeek dayOfWeek);
+    List<Slot> findAllByUserAndDayOfWeekAndActiveTrueOrderByStartTimeAsc(User user, DayOfWeek dayOfWeek);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,15 +57,17 @@ public class SlotServiceImpl implements SlotService {
     @Override
     public void deleteSlot(UUID slotId) {
         Slot slot = getSlotByIdOrThrowException(slotId);
+
         validateSlotIsActive(slot);
         validateSlotHasNoStudents(slot);
+        deleteFutureSpecificSlotsPhysically(slot);
         logicallyDeleteSpecificSlots(slot);
         slot.setActive(false);
         slotRepository.save(slot);
     }
 
     private List<Slot> getSlotsByUserAndDayOfWeek(User user, DayOfWeek dayOfWeek) {
-        return slotRepository.findAllByUserIdAndDayOfWeekAndActiveTrueOrdered(user, dayOfWeek);
+        return slotRepository.findAllByUserAndDayOfWeekAndActiveTrueOrderByStartTimeAsc(user, dayOfWeek);
     }
     private Collector<UserSlotResponse, Object, UserSlotsResponse> collectListAndBuildListSlotsResponse() {
         return Collectors.collectingAndThen(
@@ -151,6 +154,14 @@ public class SlotServiceImpl implements SlotService {
         if (!slot.getStudents().isEmpty()) {
             throw new ResponseStatusException(BAD_REQUEST, "No se puede eliminar el turno ya que tiene alumnos asociados");
         }
+    }
+
+    private void deleteFutureSpecificSlotsPhysically(Slot slot) {
+        LocalDate today = LocalDate.now();
+
+        slot.getSpecificSlots().removeIf(specificSlot ->
+                specificSlot.getSlotDate().isAfter(today) ||
+                        (specificSlot.getSlotDate().isEqual(today) && specificSlot.getStartTime().isAfter(LocalTime.now())));
     }
 
     private void logicallyDeleteSpecificSlots(Slot slot) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -64,7 +64,7 @@ public class SlotServiceImpl implements SlotService {
     }
 
     private List<Slot> getSlotsByUserAndDayOfWeek(User user, DayOfWeek dayOfWeek) {
-        return slotRepository.findAllByUserIdAndDayOfWeekOrdered(user, dayOfWeek);
+        return slotRepository.findAllByUserIdAndDayOfWeekAndActiveTrueOrdered(user, dayOfWeek);
     }
     private Collector<UserSlotResponse, Object, UserSlotsResponse> collectListAndBuildListSlotsResponse() {
         return Collectors.collectingAndThen(

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -56,7 +56,11 @@ public class SlotServiceImpl implements SlotService {
     @Override
     public void deleteSlot(UUID slotId) {
         Slot slot = getSlotByIdOrThrowException(slotId);
-        slotRepository.delete(slot);
+        validateSlotIsActive(slot);
+        validateSlotHasNoStudents(slot);
+        logicallyDeleteSpecificSlots(slot);
+        slot.setActive(false);
+        slotRepository.save(slot);
     }
 
     private List<Slot> getSlotsByUserAndDayOfWeek(User user, DayOfWeek dayOfWeek) {
@@ -136,5 +140,21 @@ public class SlotServiceImpl implements SlotService {
 
     private User getUserByIdOrThrowException(UUID userId) {
         return userService.getUserByIdOrThrowException(userId);
+    }
+
+    private void validateSlotIsActive(Slot slot) {
+        if (!slot.isActive()) {throw new ResponseStatusException(BAD_REQUEST, "El turno ya fue eliminado");
+        }
+    }
+
+    private void validateSlotHasNoStudents(Slot slot) {
+        if (!slot.getStudents().isEmpty()) {
+            throw new ResponseStatusException(BAD_REQUEST, "No se puede eliminar el turno ya que tiene alumnos asociados");
+        }
+    }
+
+    private void logicallyDeleteSpecificSlots(Slot slot) {
+        slot.getSpecificSlots()
+                .forEach(specificSlot -> specificSlot.setStatus(SpecificSlotStatus.DELETED));
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -11,6 +11,7 @@ import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.data.repositories.SlotRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
 import com.three_tech_solutions.slot_app.services.interfaces.UserService;
+import jakarta.transaction.Transactional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -55,6 +56,7 @@ public class SlotServiceImpl implements SlotService {
     }
 
     @Override
+    @Transactional
     public void deleteSlot(UUID slotId) {
         Slot slot = getSlotByIdOrThrowException(slotId);
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -1,7 +1,7 @@
 package com.three_tech_solutions.slot_app.services.implementations;
 
 import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
-import com.three_tech_solutions.slot_app.data.enums.SlotStatus;
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.models.Slot;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.User;
@@ -35,6 +35,17 @@ public class SlotServiceImpl implements SlotService {
             throw new ResponseStatusException(BAD_REQUEST, "Ya existe un turno que coincide con el día y horario ingresado");
         
         slotRepository.save(buildSlot(request));
+    }
+
+    @Override
+    public void deleteSlot(UUID slotId) {
+        Slot slot = getSlotByIdOrThrowException(slotId);
+        slotRepository.delete(slot);
+    }
+
+    private Slot getSlotByIdOrThrowException(UUID slotId) {
+        return slotRepository.findById(slotId)
+                .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "El turno no existe."));
     }
 
     private boolean timeSlotIsAlreadyUsed(CreateSlotRequest request) {
@@ -85,7 +96,7 @@ public class SlotServiceImpl implements SlotService {
                 slotCapacity,
                 request.startTime(),
                 request.startTime().plusMinutes(slotDurationMinutes),
-                SlotStatus.CREATED
+                SpecificSlotStatus.CREATED
         );
     }
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -2,6 +2,10 @@ package com.three_tech_solutions.slot_app.services.interfaces;
 
 import com.three_tech_solutions.slot_app.controllers.requests.CreateSlotRequest;
 
+import java.util.UUID;
+
 public interface SlotService {
     void createSlot(CreateSlotRequest request);
+
+    void deleteSlot(UUID slotId);
 }


### PR DESCRIPTION
Se expone endpoint para eliminar un turno.
La eliminación se hace de manera lógica, como así también de sus los respectivos SpecificSlots asociados.
Si hay alumnos asociados al slot no se permite la eliminación.
<img width="616" height="225" alt="image" src="https://github.com/user-attachments/assets/05c468ac-652c-4ed8-a67b-d07d918ca4bd" />

Si el turno ya se encuentra eliminado:
<img width="615" height="234" alt="image" src="https://github.com/user-attachments/assets/e8144076-d51d-474a-bd6c-8c9b7fb67d81" />
Si el turno no existe:
<img width="616" height="223" alt="image" src="https://github.com/user-attachments/assets/9a44b132-2d5c-48ba-8c6a-1c0dde8e3ea9" />
También se implementó eliminar físicamente los specificSlots futuros que estaban creados, a partir de la fecha y hora en que se elije eliminarlos en adelante