### PR TITLE
Feature.slot 175.activate a previously deleted slot

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SlotRepository extends JpaRepository<Slot, UUID> {
@@ -17,16 +18,32 @@ public interface SlotRepository extends JpaRepository<Slot, UUID> {
         SELECT COUNT(s) > 0
         FROM Slot s
         WHERE s.active = true
-            AND s.dayOfWeek = :dayOfWeek
-            AND :time >= s.startTime
-            AND :time <  s.endTime
-            AND (:excludedSlotId IS NULL OR s.id <> :excludedSlotId)
+          AND s.dayOfWeek = :dayOfWeek
+          AND :startTime < s.endTime
+          AND :endTime > s.startTime
+          AND (:excludedSlotId IS NULL OR s.id <> :excludedSlotId)
     """)
-    boolean existsWithinRange(
-            @Param("time") LocalTime time,
+    boolean existsActiveSlotWithinRange(
             @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime,
             @Param("excludedSlotId") UUID excludedSlotId
     );
+
+    @Query("""
+        SELECT s
+        FROM Slot s
+        WHERE s.user = :user
+          AND s.active = false
+          AND s.dayOfWeek = :dayOfWeek
+          AND s.startTime = :startTime
+    """)
+    Optional<Slot> findInactiveExactSlot(
+            @Param("user") User user,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            @Param("startTime") LocalTime startTime
+    );
+
 
     @Query("""
         SELECT s

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SlotRepository.java
@@ -16,7 +16,8 @@ public interface SlotRepository extends JpaRepository<Slot, UUID> {
     @Query("""
         SELECT COUNT(s) > 0
         FROM Slot s
-        WHERE :dayOfWeek = s.dayOfWeek
+        WHERE s.active = true
+            AND s.dayOfWeek = :dayOfWeek
             AND :time >= s.startTime
             AND :time <  s.endTime
             AND (:excludedSlotId IS NULL OR s.id <> :excludedSlotId)

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -249,6 +249,7 @@ public class SlotServiceImpl implements SlotService {
 
     private void transferStudents(Slot from, Slot to) {
         to.getStudents().addAll(from.getStudents());
+        from.getStudents().clear();
     }
 
     private void updateSlotSchedule(

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -22,10 +22,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -48,8 +45,15 @@ public class SlotServiceImpl implements SlotService {
 
     @Override
     public void createSlot(CreateSlotRequest request) {
-        validateNoConflictingSlot(request.dayOfWeek(), request.startTime(), null);
-        slotRepository.save(buildSlot(request));
+        User user = getUserByIdOrThrowException(request.userId());
+        validateNoActiveConflicts(request.dayOfWeek(), request.startTime(), null);
+        Optional<Slot> inactiveSlot = findInactiveExactSlot(user, request.dayOfWeek(), request.startTime());
+        if (inactiveSlot.isPresent()) {
+            recoverSlot(inactiveSlot.get(), user);
+        } else {
+            Slot newSlot = buildSlot(request, user);
+            slotRepository.save(newSlot);
+        }
     }
 
     @Override
@@ -70,14 +74,26 @@ public class SlotServiceImpl implements SlotService {
     }
 
     @Override
-    public UserSlotResponse updateSlot(UUID slotId, UpdateSlotRequest updateSlotRequest) {
-        Slot slot = getSlotByIdOrThrowException(slotId);
-        validateStartTimeIsDifferent(slot, updateSlotRequest);
-        validateNoConflictingSlot(slot.getDayOfWeek(), updateSlotRequest.startTime(), slot.getId());
-        slotMapper.updateSlot(slot, updateSlotRequest);
-        slot.setEndTime(calculateEndTime(slot.getUser(), slot.getStartTime()));
-        slotRepository.save(slot);
-        return slotMapper.toSlotResponse(slot, calculateUsedCapacity(slot));
+    public UserSlotResponse updateSlot(UUID slotId, UpdateSlotRequest request) {
+        Slot oldSlot = getSlotByIdOrThrowException(slotId);
+        User user = oldSlot.getUser();
+
+        validateStartTimeIsDifferent(oldSlot, request);
+        validateNoActiveConflicts(oldSlot.getDayOfWeek(), request.startTime(), slotId);
+        Optional<Slot> inactiveSlot = findInactiveExactSlot(user, oldSlot.getDayOfWeek(), request.startTime());
+        Slot finalSlot;
+
+        if (inactiveSlot.isPresent()) {
+            Slot recoveredSlot = inactiveSlot.get();
+            transferStudents(oldSlot, recoveredSlot);
+            deactivateSlot(oldSlot);
+            finalSlot = recoverSlot(recoveredSlot, user);
+        } else {
+            updateSlotInPlace(oldSlot, request, user);
+            finalSlot = slotRepository.save(oldSlot);
+        }
+
+        return slotMapper.toSlotResponse(finalSlot, calculateUsedCapacity(finalSlot));
     }
 
     @Override
@@ -147,67 +163,127 @@ public class SlotServiceImpl implements SlotService {
                 .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "No se encontró el turno"));
     }
 
-    private Slot buildSlot(CreateSlotRequest request) {
-        User user = getUserByIdOrThrowException(request.userId());
-        return new Slot(
+    private Slot buildSlot(CreateSlotRequest request, User user) {
+        Slot slot = new Slot(
                 request.dayOfWeek(),
                 request.startTime(),
                 calculateEndTime(user, request.startTime()),
                 user.getUserPreferences().getSlotCapacity(),
                 user,
+                new ArrayList<>()
+        );
+        LocalDate firstDate = getNextDateOfDayOfWeek(request.dayOfWeek());
+        slot.setSpecificSlots(
                 createSpecificSlots(
-                        request,
-                        user.getUserPreferences().getSlotDurationMinutes(),
-                        user.getUserPreferences().getSlotCapacity()
+                        slot,
+                        firstDate,
+                        user.getUserPreferences().getSlotDurationMinutes()
                 )
         );
+
+        return slot;
+    }
+
+    private List<SpecificSlot> createSpecificSlotsFromToday(
+            Slot slot,
+            User user
+    ) {
+        LocalDate firstDate = getNextDateOfDayOfWeek(slot.getDayOfWeek());
+        long duration = user.getUserPreferences().getSlotDurationMinutes();
+
+        return createSpecificSlots(slot, firstDate, duration);
     }
 
     private List<SpecificSlot> createSpecificSlots(
-            CreateSlotRequest request,
-            long slotDurationMinutes,
-            byte slotCapacity
+            Slot slot,
+            LocalDate date,
+            long slotDurationMinutes
     ) {
         List<SpecificSlot> specificSlots = new ArrayList<>();
-        LocalDate date = getNextDateOfDayOfWeek(request);
         LocalDate endDate = date.plusMonths(2);
 
         while (date.isBefore(endDate) || date.isEqual(endDate)) {
-            specificSlots.add(buildSpecificSlot(request, date, slotCapacity, slotDurationMinutes));
+            specificSlots.add(buildSpecificSlot(slot, date, slotDurationMinutes));
             date = date.plusWeeks(1);
         }
 
         return specificSlots;
     }
 
+    private void deactivateSlot(Slot slot) {
+        deleteFutureSpecificSlotsPhysically(slot);
+        slot.setActive(false);
+        slotRepository.save(slot);
+    }
+
     private SpecificSlot buildSpecificSlot(
-            CreateSlotRequest request,
+            Slot slot,
             LocalDate startDate,
-            byte slotCapacity,
             long slotDurationMinutes
     ) {
         return new SpecificSlot(
                 startDate,
-                slotCapacity,
-                request.startTime(),
-                request.startTime().plusMinutes(slotDurationMinutes),
+                slot.getCapacity(),
+                slot.getStartTime(),
+                slot.getStartTime().plusMinutes(slotDurationMinutes),
                 SpecificSlotStatus.CREATED
         );
     }
 
-    private static LocalDate getNextDateOfDayOfWeek(CreateSlotRequest request) {
-        return LocalDate.now().with(TemporalAdjusters.next(request.dayOfWeek()));
+    private static LocalDate getNextDateOfDayOfWeek(DayOfWeek dayOfWeek) {
+        return LocalDate.now().with(TemporalAdjusters.next(dayOfWeek));
     }
 
     private User getUserByIdOrThrowException(UUID userId) {
         return userService.getUserByIdOrThrowException(userId);
     }
 
-    private void validateNoConflictingSlot(DayOfWeek dayOfWeek, LocalTime startTime, UUID excludedSlotId) {
+    private void validateNoActiveConflicts(DayOfWeek dayOfWeek, LocalTime startTime, UUID excludedSlotId) {
         if (slotRepository.existsWithinRange(startTime, dayOfWeek, excludedSlotId)) {
-            throw new ResponseStatusException(BAD_REQUEST, "Ya existe un turno que coincide con el día y horario ingresado");
+            throw new ResponseStatusException(BAD_REQUEST, "Ya existe un turno que coincide con el día y el rango de horario ingresado");
         }
     }
+
+    private Optional<Slot> findInactiveExactSlot(User user, DayOfWeek dayOfWeek, LocalTime startTime) {
+        return slotRepository.findAllByUserAndOptionalDayOfWeek(user, dayOfWeek)
+                .stream()
+                .filter(slot ->
+                        !slot.isActive()
+                                && slot.getStartTime().equals(startTime)
+                )
+                .findFirst();
+    }
+
+    private Slot recoverSlot(Slot slot, User user) {
+        slot.setActive(true);
+
+        deleteFutureSpecificSlotsPhysically(slot);
+
+        slot.getSpecificSlots().addAll(
+                createSpecificSlotsFromToday(slot, user)
+        );
+
+        return slotRepository.save(slot);
+    }
+
+    private void transferStudents(Slot from, Slot to) {
+        to.getStudents().addAll(from.getStudents());
+    }
+
+    private void updateSlotInPlace(
+            Slot slot,
+            UpdateSlotRequest request,
+            User user
+    ) {
+        slot.setStartTime(request.startTime());
+        slot.setEndTime(calculateEndTime(user, request.startTime()));
+
+        slot.getSpecificSlots().clear();
+        slot.getSpecificSlots().addAll(
+                createSpecificSlotsFromToday(slot, user)
+        );
+    }
+
 
     private LocalTime calculateEndTime(User user, LocalTime startTime) {
         return startTime.plusMinutes(user.getUserPreferences().getSlotDurationMinutes());

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -77,19 +77,19 @@ public class SlotServiceImpl implements SlotService {
     public UserSlotResponse updateSlot(UUID slotId, UpdateSlotRequest request) {
         Slot oldSlot = getSlotByIdOrThrowException(slotId);
         User user = oldSlot.getUser();
-
         validateStartTimeIsDifferent(oldSlot, request);
-        validateNoActiveConflicts(oldSlot.getDayOfWeek(), request.startTime(), calculateEndTime(user, request.startTime()), null);
+        validateNoActiveConflicts(oldSlot.getDayOfWeek(), request.startTime(), calculateEndTime(user, request.startTime()), slotId);
         Optional<Slot> inactiveSlot = findInactiveExactSlot(user, oldSlot.getDayOfWeek(), request.startTime());
         Slot finalSlot;
 
         if (inactiveSlot.isPresent()) {
             Slot recoveredSlot = inactiveSlot.get();
             transferStudents(oldSlot, recoveredSlot);
-            deactivateSlot(oldSlot);
+            inactivateSlot(oldSlot);
+            slotRepository.save(oldSlot);
             finalSlot = recoverSlot(recoveredSlot, user);
         } else {
-            updateSlotInPlace(oldSlot, request, user);
+            updateSlotSchedule(oldSlot, request, user);
             finalSlot = slotRepository.save(oldSlot);
         }
 
@@ -100,12 +100,10 @@ public class SlotServiceImpl implements SlotService {
     @Transactional
     public void deleteSlot(UUID slotId) {
         Slot slot = getSlotByIdOrThrowException(slotId);
-
         validateSlotIsActive(slot);
         validateSlotHasNoStudents(slot);
-        deleteFutureSpecificSlotsPhysically(slot);
+        inactivateSlot(slot);
         logicallyDeleteSpecificSlots(slot);
-        slot.setActive(false);
         slotRepository.save(slot);
     }
 
@@ -172,14 +170,7 @@ public class SlotServiceImpl implements SlotService {
                 user,
                 new ArrayList<>()
         );
-        LocalDate firstDate = getNextDateOfDayOfWeek(request.dayOfWeek());
-        slot.setSpecificSlots(
-                createSpecificSlots(
-                        slot,
-                        firstDate,
-                        user.getUserPreferences().getSlotDurationMinutes()
-                )
-        );
+        slot.setSpecificSlots(createSpecificSlotsFromToday(slot, user));
 
         return slot;
     }
@@ -210,10 +201,9 @@ public class SlotServiceImpl implements SlotService {
         return specificSlots;
     }
 
-    private void deactivateSlot(Slot slot) {
+    private void inactivateSlot(Slot slot) {
         deleteFutureSpecificSlotsPhysically(slot);
         slot.setActive(false);
-        slotRepository.save(slot);
     }
 
     private SpecificSlot buildSpecificSlot(
@@ -250,9 +240,6 @@ public class SlotServiceImpl implements SlotService {
 
     private Slot recoverSlot(Slot slot, User user) {
         slot.setActive(true);
-
-        deleteFutureSpecificSlotsPhysically(slot);
-
         slot.getSpecificSlots().addAll(
                 createSpecificSlotsFromToday(slot, user)
         );
@@ -264,7 +251,7 @@ public class SlotServiceImpl implements SlotService {
         to.getStudents().addAll(from.getStudents());
     }
 
-    private void updateSlotInPlace(
+    private void updateSlotSchedule(
             Slot slot,
             UpdateSlotRequest request,
             User user

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -46,7 +46,7 @@ public class SlotServiceImpl implements SlotService {
     @Override
     public void createSlot(CreateSlotRequest request) {
         User user = getUserByIdOrThrowException(request.userId());
-        validateNoActiveConflicts(request.dayOfWeek(), request.startTime(), null);
+        validateNoActiveConflicts(request.dayOfWeek(), request.startTime(), calculateEndTime(user, request.startTime()), null);
         Optional<Slot> inactiveSlot = findInactiveExactSlot(user, request.dayOfWeek(), request.startTime());
         if (inactiveSlot.isPresent()) {
             recoverSlot(inactiveSlot.get(), user);
@@ -79,7 +79,7 @@ public class SlotServiceImpl implements SlotService {
         User user = oldSlot.getUser();
 
         validateStartTimeIsDifferent(oldSlot, request);
-        validateNoActiveConflicts(oldSlot.getDayOfWeek(), request.startTime(), slotId);
+        validateNoActiveConflicts(oldSlot.getDayOfWeek(), request.startTime(), calculateEndTime(user, request.startTime()), null);
         Optional<Slot> inactiveSlot = findInactiveExactSlot(user, oldSlot.getDayOfWeek(), request.startTime());
         Slot finalSlot;
 
@@ -238,20 +238,14 @@ public class SlotServiceImpl implements SlotService {
         return userService.getUserByIdOrThrowException(userId);
     }
 
-    private void validateNoActiveConflicts(DayOfWeek dayOfWeek, LocalTime startTime, UUID excludedSlotId) {
-        if (slotRepository.existsWithinRange(startTime, dayOfWeek, excludedSlotId)) {
+    private void validateNoActiveConflicts(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, UUID excludedSlotId) {
+        if (slotRepository.existsActiveSlotWithinRange(dayOfWeek, startTime, endTime, excludedSlotId)) {
             throw new ResponseStatusException(BAD_REQUEST, "Ya existe un turno que coincide con el día y el rango de horario ingresado");
         }
     }
 
     private Optional<Slot> findInactiveExactSlot(User user, DayOfWeek dayOfWeek, LocalTime startTime) {
-        return slotRepository.findAllByUserAndOptionalDayOfWeek(user, dayOfWeek)
-                .stream()
-                .filter(slot ->
-                        !slot.isActive()
-                                && slot.getStartTime().equals(startTime)
-                )
-                .findFirst();
+        return slotRepository.findInactiveExactSlot(user, dayOfWeek, startTime);
     }
 
     private Slot recoverSlot(Slot slot, User user) {


### PR DESCRIPTION
Se modificó tanto el endpoint de creación de turno como el de update, para que si un turno dado un dia de semana y horario en particular ya existe, se debe dar de alta y registrar los turnos especificos a partir de la fecha actual.
Teniendo los siguientes slots y eliminado logicamente el slot de las 9:
<img width="505" height="76" alt="image" src="https://github.com/user-attachments/assets/4ddb2c93-3177-4537-bed5-0b16c9057059" />
Si se quiere crear un slot nuevamente al mismo horario de las 9:
<img width="527" height="209" alt="image" src="https://github.com/user-attachments/assets/ad89dbd0-2245-4be3-b1e0-c3fc621cccd0" />
Se recupera el slot inactivo. Se puede ver que no se creo un cuarto slot, sino que se activó, y se crearon sus respectivos specifisSlots
<img width="507" height="78" alt="image" src="https://github.com/user-attachments/assets/fc85901f-a69d-4d6f-bed0-4ace2792252b" />
<img width="501" height="234" alt="image" src="https://github.com/user-attachments/assets/3a46d4ad-bcae-44f3-81d1-6f361f8480e3" />
Si al crear un slot no se encuentra coincidencias con un slot inactivo para recuperarlo, se crea uno nuevo:
<img width="511" height="93" alt="image" src="https://github.com/user-attachments/assets/476b3118-4307-439d-9677-eb3f84f89f05" />

En el caso de actualizar un slot, Si se encuentra una coincidencia con un slot ianctivo en el mismo horario:
-tambien se recupera el slot inactivo y se crean sus specificSlot
-Se da baja el anterior slot y se eliminan fisicamnte los specificSlot que todavia no pasaron.
-Se pisan los alumnos al nuevo slot.

ejemplo: se tiene el slot de las 9 inactivo:
<img width="507" height="90" alt="image" src="https://github.com/user-attachments/assets/7d386bfb-3ca1-4aba-ade9-ef54b8931cf7" />
y se quiere actualizar el slot de las 10 a las 9, teniendo el de las 10 su alumna asociada:
<img width="467" height="400" alt="image" src="https://github.com/user-attachments/assets/15731d6b-6759-4584-bea6-948cde9a5de9" />

Se actualiza el horario a las 9:
<img width="528" height="289" alt="image" src="https://github.com/user-attachments/assets/c0260402-db29-49c9-b9ca-d66bf089dee7" />
con su alumna asociada ahora solo al slot de las 9:
<img width="438" height="382" alt="image" src="https://github.com/user-attachments/assets/b15a9aea-57ed-4f2d-b577-b3ffadb5e4fb" />

 Caso contrario a encontrar un slot inactivo con el horario exacto, se actualiza el horario del slot actual, y se vuelven a crear sus specificSlot actualizados.
 
 -Además, tambien se corrigio que la validación de conflictos sea solo contra slots activos, evitando detectar conflictos con slots que ya fueron eliminados o desactivados.

- Tambien se corrigió la lógica de validación del rango horario, ya que antes solo se validaba si el startTime del nuevo slot se encontraba dentro del rango de otro slot, lo que permitía superposiciones parciales.
Por ejemplo, si existía un slot activo de 9:00 a 10:00, era posible crear uno de 8:30 a 9:30, ya que el startTime no estaba dentro del rango 9:00–10:00, aunque ambos se solapaban.
Ahora se valida correctamente el rango completo del slot, evitando cualquier tipo de superposición.