### PR TITLE
[FIX][SLOT-173]: implementation of logic to edit capacity

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -101,6 +101,39 @@ public class SlotServiceImpl implements SlotService {
                 .toList();
     }
 
+    @Override
+    public void validateFutureSpecificSlotsCapacity(User user, byte newCapacity) {
+        getFutureSpecificSlots(user).stream()
+                .filter(specificSlot ->
+                        specificSlot.getSpecificSlotDetails().size() > newCapacity
+                )
+                .findAny()
+                .ifPresent(s -> {
+                    throw new ResponseStatusException(
+                            BAD_REQUEST,
+                            "La nueva capacidad es menor a la cantidad de alumnos inscriptos en uno o más turnos futuros"
+                    );
+                });
+    }
+
+    @Override
+    public void updateFutureSpecificSlotsCapacity(User user, byte newCapacity) {
+
+        getFutureSpecificSlots(user)
+                .forEach(specificSlot -> specificSlot.setCapacity(newCapacity));
+    }
+
+    private List<SpecificSlot> getFutureSpecificSlots(User user) {
+        LocalDate today = LocalDate.now();
+        return user.getSlots().stream()
+                .flatMap(slot -> slot.getSpecificSlots().stream())
+                .filter(specificSlot ->
+                        !specificSlot.getSlotDate().isBefore(today)
+                )
+                .toList();
+    }
+
+
     private List<Slot> getSlots(User user, DayOfWeek dayOfWeek) {
         return slotRepository.findAllByUserAndOptionalDayOfWeek(user, dayOfWeek);
     }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.three_tech_solutions.slot_app.data.mappers.UserPreferencesMapper;
 import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.data.repositories.UserRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.*;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -88,14 +89,15 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void updateUserCapacityPreference(UUID userId, UpdateUserCapacityRequest updateUserCapacityRequest) {
-        this.userRepository.findById(userId)
-                .ifPresentOrElse(
-                        (user) -> updateUserCapacityAndSaveIt(updateUserCapacityRequest, user),
-                        () -> {
-                            throw new ResponseStatusException(BAD_REQUEST, "Hubo un error al encontrar el usuario");
-                        }
-                );
+    @Transactional
+    public void updateUserCapacityPreference(UUID userId, UpdateUserCapacityRequest request) {
+        User user = getUserByIdOrThrowException(userId);
+        byte newCapacity = request.capacity();
+
+        slotService.validateFutureSpecificSlotsCapacity(user, newCapacity);
+        user.getUserPreferences().setSlotCapacity(newCapacity);
+        slotService.updateFutureSpecificSlotsCapacity(user, newCapacity);
+        userRepository.save(user);
     }
 
     @Override
@@ -115,10 +117,5 @@ public class UserServiceImpl implements UserService {
         return this.userRepository.findById(userId)
                 .map(userPreferencesMapper::toUserPreferencesResponse)
                 .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Hubo un error al encontrar el usuario"));
-    }
-
-    private void updateUserCapacityAndSaveIt(UpdateUserCapacityRequest updateUserCapacityRequest, User user) {
-        user.getUserPreferences().setSlotCapacity(updateUserCapacityRequest.capacity());
-        userRepository.save(user);
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -26,4 +26,9 @@ public interface SlotService {
     void deleteSlot(UUID slotId);
 
     List<StudentSlotResponse> getSlotsByStudent(Student student);
+
+    void validateFutureSpecificSlotsCapacity(User user, byte newCapacity);
+
+    void updateFutureSpecificSlotsCapacity(User user, byte newCapacity);
+
 }


### PR DESCRIPTION
"Al editar la capacidad de los turnos, se actualiza la capacidad global pero no la capacidad de cada uno de los turnos previamente creados. Debe actualizarse la capacidad global y también la de cada turno ya registrado"
Se incorporó una validación previa basada en los SpecificSlot futuros del usuario:
Antes de actualizar la capacidad:
-se valida que ningún SpecificSlot futuro tenga más alumnos inscriptos que la nueva capacidad
-en caso contrario, se lanza una excepción y se aborta el proceso
Si la validación es exitosa:
-se actualiza la capacidad global del usuario
-se propaga la nueva capacidad a todos los SpecificSlot futuros
<img width="249" height="106" alt="image" src="https://github.com/user-attachments/assets/723c3e0a-18d9-453f-beaa-12231e67b26b" />
<img width="548" height="157" alt="image" src="https://github.com/user-attachments/assets/0596bf98-7746-4fde-b3c1-5fab39ef6ffd" />
Se actualiza la capacidad de los specifics slots futuros