### PR TITLE
[FTR][SLOT-148] Cancelar un turno

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SpecificSlotControllerImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/implementations/SpecificSlotControllerImpl.java
@@ -1,0 +1,23 @@
+package com.three_tech_solutions.slot_app.controllers.implementations;
+
+import com.three_tech_solutions.slot_app.controllers.interfaces.SpecificSlotsController;
+import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+public class SpecificSlotControllerImpl implements SpecificSlotsController {
+
+    private final SpecificSlotService specificSlotService;
+
+    @Override
+    public void cancelSpecificSlot(
+            UUID specificSlotId,
+            boolean studentsMustRecoverSlot
+    ) {
+        specificSlotService.cancelSpecificSlot(specificSlotId, studentsMustRecoverSlot);
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SpecificSlotsController.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/interfaces/SpecificSlotsController.java
@@ -1,0 +1,17 @@
+package com.three_tech_solutions.slot_app.controllers.interfaces;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@RequestMapping("/specific-slots")
+public interface SpecificSlotsController {
+    @PostMapping("/{specificSlotId}/cancel")
+    void cancelSpecificSlot(
+            @PathVariable UUID specificSlotId,
+            @RequestParam(required = false, defaultValue = "true") boolean studentsMustRecoverSlot
+    );
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SpecificSlotDetailRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SpecificSlotDetailRepository.java
@@ -1,4 +1,4 @@
-package com.three_tech_solutions.slot_app.controllers.interfaces;
+package com.three_tech_solutions.slot_app.data.repositories;
 
 import com.three_tech_solutions.slot_app.data.models.SpecificSlotDetail;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotDetailServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotDetailServiceImpl.java
@@ -1,8 +1,8 @@
 package com.three_tech_solutions.slot_app.services.implementations;
 
-import com.three_tech_solutions.slot_app.controllers.interfaces.SpecificSlotDetailRepository;
 import com.three_tech_solutions.slot_app.data.enums.SpecificSlotDetailStatus;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlotDetail;
+import com.three_tech_solutions.slot_app.data.repositories.SpecificSlotDetailRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotDetailService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +21,7 @@ public class SpecificSlotDetailServiceImpl implements SpecificSlotDetailService 
         return specificSlotDetailRepository.findBySpecificSlotIdAndStudentId(specificSlotId, studentId);
     }
 
+    @Override
     public void registerAbsence(SpecificSlotDetail specificSlotDetail) {
         specificSlotDetail.setStatus(SpecificSlotDetailStatus.ABSENCE);
         specificSlotDetailRepository.save(specificSlotDetail);

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -44,6 +44,8 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
     @Override
     public void cancelSpecificSlot(UUID specificSlotId, boolean studentsMustRecoverSlot) {
         SpecificSlot specificSlot = getSpecificSlotByIdOrThrowException(specificSlotId);
+        validateIfSpecificSlotIsNotAlreadyCanceled(specificSlot);
+
         if (studentsMustRecoverSlot) {
             specificSlot
                     .getSpecificSlotDetails()
@@ -55,6 +57,12 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
         specificSlot.setStatus(CANCELED);
         specificSlot.setSpecificSlotDetails(Collections.emptyList());
         specificSlotRepository.save(specificSlot);
+    }
+
+    private static void validateIfSpecificSlotIsNotAlreadyCanceled(SpecificSlot specificSlot) {
+        if (specificSlot.getStatus() == CANCELED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El turno ya se encuentra cancelado");
+        }
     }
 
     private void registerAbsenceForStudent(UUID specificSlotId, SpecificSlotDetail specificSlotDetail) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -1,22 +1,29 @@
 package com.three_tech_solutions.slot_app.services.implementations;
 
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
+import com.three_tech_solutions.slot_app.data.models.SpecificSlotDetail;
 import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.data.repositories.SpecificSlotRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotService;
+import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+
+import static com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus.CANCELED;
 
 @Service
 @AllArgsConstructor
 public class SpecificSlotServiceImpl implements SpecificSlotService {
+
     private final SpecificSlotRepository specificSlotRepository;
+    private final StudentService studentService;
 
     @Override
     public List<SpecificSlot> getAllByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate) {
@@ -32,5 +39,28 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
     @Override
     public void saveSpecificSlot(SpecificSlot specificSlot) {
         this.specificSlotRepository.save(specificSlot);
+    }
+
+    @Override
+    public void cancelSpecificSlot(UUID specificSlotId, boolean studentsMustRecoverSlot) {
+        SpecificSlot specificSlot = getSpecificSlotByIdOrThrowException(specificSlotId);
+        if (studentsMustRecoverSlot) {
+            specificSlot
+                    .getSpecificSlotDetails()
+                    .forEach(specificSlotDetail ->
+                            registerAbsenceForStudent(specificSlotId, specificSlotDetail)
+                    );
+        }
+
+        specificSlot.setStatus(CANCELED);
+        specificSlot.setSpecificSlotDetails(Collections.emptyList());
+        specificSlotRepository.save(specificSlot);
+    }
+
+    private void registerAbsenceForStudent(UUID specificSlotId, SpecificSlotDetail specificSlotDetail) {
+        studentService.registerStudentAbsenceForSpecificSlot(
+                specificSlotDetail.getStudent().getId(),
+                specificSlotId
+        );
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -6,11 +6,7 @@ import com.three_tech_solutions.slot_app.controllers.responses.StudentDetailsRes
 import com.three_tech_solutions.slot_app.controllers.responses.StudentMonthlyFeeResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.StudentResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
-import com.three_tech_solutions.slot_app.data.enums.AbsenceStatus;
-import com.three_tech_solutions.slot_app.data.enums.MonthlyFeeStatus;
-import com.three_tech_solutions.slot_app.data.enums.PaymentPlanName;
-import com.three_tech_solutions.slot_app.data.enums.StudentSituation;
-import com.three_tech_solutions.slot_app.data.enums.SpecificSlotDetailStatus;
+import com.three_tech_solutions.slot_app.data.enums.*;
 import com.three_tech_solutions.slot_app.data.mappers.StudentMapper;
 import com.three_tech_solutions.slot_app.data.models.*;
 import com.three_tech_solutions.slot_app.data.repositories.StudentRepository;
@@ -46,7 +42,7 @@ public class StudentServiceImpl implements StudentService {
     private final MonthlyFeeService monthlyFeeService;
     private final SlotService slotService;
     private final PlanService planService;
-    private final SpecificSlotDetailServiceImpl specificSlotDetailService;
+    private final SpecificSlotDetailService specificSlotDetailService;
     private final SpecificSlotService specificSlotService;
 
     public StudentServiceImpl(
@@ -56,8 +52,8 @@ public class StudentServiceImpl implements StudentService {
             @Lazy MonthlyFeeService monthlyFeeService,
             @Lazy PlanService planService,
             @Lazy SlotService slotService,
-            SpecificSlotDetailServiceImpl specificSlotDetailService,
-            SpecificSlotService specificSlotService
+            SpecificSlotDetailService specificSlotDetailService,
+            @Lazy SpecificSlotService specificSlotService
     ) {
         this.studentRepository = studentRepository;
         this.studentMapper = studentMapper;

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotDetailService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotDetailService.java
@@ -7,4 +7,6 @@ import java.util.UUID;
 
 public interface SpecificSlotDetailService {
     Optional<SpecificSlotDetail> getSpecificSlotDetailBySpecificSlotIdAndStudentId(UUID specificSlotId, UUID studentId);
+
+    void registerAbsence(SpecificSlotDetail specificSlotDetail);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
@@ -13,4 +13,6 @@ public interface SpecificSlotService {
     SpecificSlot getSpecificSlotByIdOrThrowException(UUID specificSlotId);
 
     void saveSpecificSlot(SpecificSlot specificSlot);
+
+    void cancelSpecificSlot(UUID specificSlotId, boolean studentsMustRecoverSlot);
 }


### PR DESCRIPTION
Se agregó un nuevo endpoint para poder cancelar un turno 

`/specific-slots/{specificSlotId}/cancel`

Que recibe un queryParam `studentsMustRecoverSlot` para indicar si se deben registrar nuevas `absence` en los estudiantes que esten en ese turno para que puedan recuperar el turno otro dia.