### PR TITLE
Fix.slot 194.fix update capacity

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/components/calendar_view_builder/CalendarViewBuilder.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/calendar_view_builder/CalendarViewBuilder.java
@@ -54,14 +54,10 @@ public abstract class CalendarViewBuilder {
                 specificSlot.getStartTime(),
                 specificSlot.getEndTime(),
                 specificSlot.getCapacity(),
-                getSpecificSlotUsedCapacity(specificSlot),
+                specificSlot.getSpecificSlotUsedCapacity(),
                 calculateStatus(specificSlot),
                 getStudentsList(specificSlot)
         );
-    }
-
-    private int getSpecificSlotUsedCapacity(SpecificSlot specificSlot) {
-        return slotService.getSpecificSlotUsedCapacity(specificSlot);
     }
 
     private static List<SpecificSlotResponse.Student> getStudentsList(SpecificSlot specificSlot) {

--- a/src/main/java/com/three_tech_solutions/slot_app/components/calendar_view_builder/CalendarViewBuilder.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/calendar_view_builder/CalendarViewBuilder.java
@@ -60,12 +60,8 @@ public abstract class CalendarViewBuilder {
         );
     }
 
-    private static int getSpecificSlotUsedCapacity(SpecificSlot specificSlot) {
-        return getStudentsWithAttendanceOrRecoveredStatus(specificSlot).size();
-    }
-
-    private static List<SpecificSlotDetail> getStudentsWithAttendanceOrRecoveredStatus(SpecificSlot specificSlot) {
-        return specificSlot.getSpecificSlotDetails().stream().filter(SpecificSlotDetail::studentGoesToSlot).toList();
+    private int getSpecificSlotUsedCapacity(SpecificSlot specificSlot) {
+        return slotService.getSpecificSlotUsedCapacity(specificSlot);
     }
 
     private static List<SpecificSlotResponse.Student> getStudentsList(SpecificSlot specificSlot) {

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -45,4 +45,12 @@ public class SpecificSlot {
     public void addStudent(Student student) {
         this.specificSlotDetails.add(new SpecificSlotDetail(student, RECOVERED));
     }
+
+    public int getSpecificSlotUsedCapacity() {
+        return getStudentsWithAttendanceOrRecoveredStatus().size();
+    }
+
+    private List<SpecificSlotDetail> getStudentsWithAttendanceOrRecoveredStatus() {
+        return this.getSpecificSlotDetails().stream().filter(SpecificSlotDetail::studentGoesToSlot).toList();
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -7,10 +7,7 @@ import com.three_tech_solutions.slot_app.controllers.responses.UserSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotsByDayResponse;
 import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.mappers.SlotMapper;
-import com.three_tech_solutions.slot_app.data.models.Slot;
-import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
-import com.three_tech_solutions.slot_app.data.models.Student;
-import com.three_tech_solutions.slot_app.data.models.User;
+import com.three_tech_solutions.slot_app.data.models.*;
 import com.three_tech_solutions.slot_app.data.repositories.SlotRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
 import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
@@ -109,9 +106,7 @@ public class SlotServiceImpl implements SlotService {
     @Override
     public void validateFutureSpecificSlotsCapacity(User user, byte newCapacity) {
         getFutureSpecificSlots(user).stream()
-                .filter(specificSlot ->
-                        specificSlot.getSpecificSlotDetails().size() > newCapacity
-                )
+                .filter(specificSlot -> exceedsCapacity(specificSlot, newCapacity))
                 .findAny()
                 .ifPresent(s -> {
                     throw new ResponseStatusException(
@@ -123,21 +118,14 @@ public class SlotServiceImpl implements SlotService {
 
     @Override
     public void updateFutureSpecificSlotsCapacity(User user, byte newCapacity) {
-
         getFutureSpecificSlots(user)
                 .forEach(specificSlot -> specificSlot.setCapacity(newCapacity));
     }
 
-    private List<SpecificSlot> getFutureSpecificSlots(User user) {
-        LocalDate today = LocalDate.now();
-        return user.getSlots().stream()
-                .flatMap(slot -> slot.getSpecificSlots().stream())
-                .filter(specificSlot ->
-                        !specificSlot.getSlotDate().isBefore(today)
-                )
-                .toList();
+    @Override
+    public int getSpecificSlotUsedCapacity(SpecificSlot specificSlot) {
+        return getStudentsWithAttendanceOrRecoveredStatus(specificSlot).size();
     }
-
 
     @Override
     public void updateSlotsForStudent(List<UUID> slotIds, Student student) {
@@ -149,6 +137,32 @@ public class SlotServiceImpl implements SlotService {
 
         slotsWhereToRemoveStudent.addAll(slotsWhereToAddStudent);
         slotRepository.saveAll(slotsWhereToRemoveStudent);
+    }
+
+    private List<SpecificSlotDetail> getStudentsWithAttendanceOrRecoveredStatus(SpecificSlot specificSlot) {
+        return specificSlot.getSpecificSlotDetails().stream().filter(SpecificSlotDetail::studentGoesToSlot).toList();
+    }
+
+    private boolean exceedsCapacity(SpecificSlot specificSlot, byte newCapacity) {
+
+        int slotUsedCapacity =
+                getSlotUsedCapacity(specificSlot.getSlot());
+
+        int specificSlotUsedCapacity =
+                getSpecificSlotUsedCapacity(specificSlot);
+
+        return newCapacity < slotUsedCapacity
+                || newCapacity < specificSlotUsedCapacity;
+    }
+
+    private List<SpecificSlot> getFutureSpecificSlots(User user) {
+        LocalDate today = LocalDate.now();
+        return user.getSlots().stream()
+                .flatMap(slot -> slot.getSpecificSlots().stream())
+                .filter(specificSlot ->
+                        !specificSlot.getSlotDate().isBefore(today)
+                )
+                .toList();
     }
 
     private List<Slot> getSlots(User user, DayOfWeek dayOfWeek) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -123,11 +123,6 @@ public class SlotServiceImpl implements SlotService {
     }
 
     @Override
-    public int getSpecificSlotUsedCapacity(SpecificSlot specificSlot) {
-        return getStudentsWithAttendanceOrRecoveredStatus(specificSlot).size();
-    }
-
-    @Override
     public void updateSlotsForStudent(List<UUID> slotIds, Student student) {
         List<Slot> slotsWhereToRemoveStudent = slotRepository.findSlotsWhereStudentIsRegistedAndNeedToBeRemoved(slotIds, student);
         List<Slot> slotsWhereToAddStudent = slotRepository.findAllWhereStudentIsNotRegisted(slotIds, student);
@@ -139,20 +134,11 @@ public class SlotServiceImpl implements SlotService {
         slotRepository.saveAll(slotsWhereToRemoveStudent);
     }
 
-    private List<SpecificSlotDetail> getStudentsWithAttendanceOrRecoveredStatus(SpecificSlot specificSlot) {
-        return specificSlot.getSpecificSlotDetails().stream().filter(SpecificSlotDetail::studentGoesToSlot).toList();
-    }
-
     private boolean exceedsCapacity(SpecificSlot specificSlot, byte newCapacity) {
+        int slotUsedCapacity = calculateUsedCapacity(specificSlot.getSlot());
+        int specificSlotUsedCapacity = specificSlot.getSpecificSlotUsedCapacity();
 
-        int slotUsedCapacity =
-                getSlotUsedCapacity(specificSlot.getSlot());
-
-        int specificSlotUsedCapacity =
-                getSpecificSlotUsedCapacity(specificSlot);
-
-        return newCapacity < slotUsedCapacity
-                || newCapacity < specificSlotUsedCapacity;
+        return newCapacity < slotUsedCapacity || newCapacity < specificSlotUsedCapacity;
     }
 
     private List<SpecificSlot> getFutureSpecificSlots(User user) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -33,6 +33,4 @@ public interface SlotService {
     void validateFutureSpecificSlotsCapacity(User user, byte newCapacity);
 
     void updateFutureSpecificSlotsCapacity(User user, byte newCapacity);
-
-    int getSpecificSlotUsedCapacity(SpecificSlot specificSlot);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -5,6 +5,7 @@ import com.three_tech_solutions.slot_app.controllers.requests.UpdateSlotRequest;
 import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotsByDayResponse;
+import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.Student;
 import com.three_tech_solutions.slot_app.data.models.User;
 
@@ -32,4 +33,6 @@ public interface SlotService {
     void validateFutureSpecificSlotsCapacity(User user, byte newCapacity);
 
     void updateFutureSpecificSlotsCapacity(User user, byte newCapacity);
+
+    int getSpecificSlotUsedCapacity(SpecificSlot specificSlot);
 }


### PR DESCRIPTION
Se corrigió y unificó el cálculo de used capacity de los SpecificSlot, que previamente se basaba solo en la cantidad de SpecificSlotDetail, lo cual generaba valores incorrectos al incluir ausencias.
Ahora:
-El cálculo de la capacidad utilizada del SpecificSlot se centralizó en el propio modelo, considerando únicamente alumnos presentes o recuperando.
-Tanto el calendario como el SlotService reutilizan este cálculo, evitando duplicación de lógica.
La validación de actualización de capacidad contempla:
-la cantidad de alumnos inscriptos en el Slot base
-y la capacidad utilizada real de los SpecificSlot futuros, que contemplan a quienes recuperan.
Esto asegura consistencia en el manejo de cupos y evita permitir capacidades inválidas.
Ejemplo:
Se tienen dos alumnos en un turno y en un specific slot, entonces el minimo de capacidad posible a actualizar es de 2:
<img width="776" height="49" alt="image" src="https://github.com/user-attachments/assets/56ae071b-612a-45df-ab52-40af42673796" />

<img width="612" height="179" alt="image" src="https://github.com/user-attachments/assets/35dc58a4-fcc4-4f15-8413-4f9cd4846ad3" />

Al recuperar otro alumno en ese mismo turno donde se encontraban las otras dos personas,el minimo de capacidad posible a actualizar ahora es de 3:
<img width="791" height="19" alt="image" src="https://github.com/user-attachments/assets/84c6272d-db69-4f8c-ace8-a7cd48134d3a" />

<img width="832" height="291" alt="image" src="https://github.com/user-attachments/assets/343828a6-3ba1-4a22-9d8e-aebb0ef1014f" />

<img width="620" height="171" alt="image" src="https://github.com/user-attachments/assets/cb3b38ea-cfd5-4fdc-98ed-df44838222bc" />