### PR TITLE
[FTR][SLOT-190]: add logic

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -73,4 +73,14 @@ public class Slot {
     }
 
 
+    public boolean isAtFullCapacity() {
+        return this.students.size() == this.capacity;
+    }
+
+    public boolean someSpecificSlotIsAtFullCapacity() {
+        return this
+                .specificSlots
+                .stream()
+                .anyMatch(SpecificSlot::isAtFullCapacity);
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -60,4 +60,8 @@ public class SpecificSlot {
     private List<SpecificSlotDetail> getStudentsWithAttendanceOrRecoveredStatus() {
         return this.getSpecificSlotDetails().stream().filter(SpecificSlotDetail::studentGoesToSlot).toList();
     }
+
+    public boolean isAtFullCapacity() {
+        return this.capacity == this.getSpecificSlotUsedCapacity();
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -7,7 +7,10 @@ import com.three_tech_solutions.slot_app.controllers.responses.UserSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotsByDayResponse;
 import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.mappers.SlotMapper;
-import com.three_tech_solutions.slot_app.data.models.*;
+import com.three_tech_solutions.slot_app.data.models.Slot;
+import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
+import com.three_tech_solutions.slot_app.data.models.Student;
+import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.data.repositories.SlotRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
 import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotService;
@@ -274,16 +277,30 @@ public class SlotServiceImpl implements SlotService {
         slotRepository.findById(slotId)
                 .ifPresentOrElse(slot -> {
                     try {
+                        validateSlotCapacity(slot);
                         slot.addStudent(student);
                         slotRepository.save(slot);
                     } catch (DataIntegrityViolationException e) {
                         throw new ResponseStatusException(BAD_REQUEST, "El estudiante ya se encuentra registrado en el turno solicitado");
+                    } catch (ResponseStatusException e) {
+                        throw e;
                     } catch (Exception e) {
+                        log.error("Error al registrar el estudiante {} en el turno {}: {}", student.getId(), slotId, e.getMessage());
                         throw new ResponseStatusException(INTERNAL_SERVER_ERROR, "Hubo un error al registrar el estudiante en el turno solicitado");
                     }
                 }, () -> {
                     throw new ResponseStatusException(BAD_REQUEST, "No se encuentra registrado el turno solicitado");
                 });
+    }
+
+    private static void validateSlotCapacity(Slot slot) {
+        if (slot.isAtFullCapacity()) {
+            throw new ResponseStatusException(BAD_REQUEST, "El turno ya se encuentra completo");
+        }
+
+        if (slot.someSpecificSlotIsAtFullCapacity()) {
+            throw new ResponseStatusException(BAD_REQUEST, "Uno o más turnos futuros ya se encuentran completos");
+        }
     }
 
     private void validateSlotHasNoStudents(Slot slot) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -12,6 +12,7 @@ import com.three_tech_solutions.slot_app.data.models.*;
 import com.three_tech_solutions.slot_app.data.repositories.StudentRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.*;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -34,6 +35,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 
 @Service
+@Slf4j
 public class StudentServiceImpl implements StudentService {
 
     private final StudentRepository studentRepository;
@@ -82,6 +84,9 @@ public class StudentServiceImpl implements StudentService {
             addStudentToSlots(studentDTO, student);
         } catch (DataIntegrityViolationException exception) {
             throw new ResponseStatusException(BAD_REQUEST, "El DNI ya existe");
+        } catch (ResponseStatusException exception) {
+            log.error("Error al crear el estudiante: {}", exception.getReason());
+            throw exception;
         } catch (Exception exception){
             throw new ResponseStatusException(INTERNAL_SERVER_ERROR,"Ocurrió un error al registrar el estudiante. Intente nuevamente");
         }


### PR DESCRIPTION
Se agrega la logica para validar la capacidad usada de un turno y de los turnos especificos a la hora de registrar un estudiante

# Ejemplo

Dado un Slot sin estudiantes registrados, se pueden registrar estudiantes a ese turno sin ningun drama

```
[
    {
        "dayOfWeek": "SUNDAY",
        "numberOfSlots": 1,
        "slots": [
            {
                "id": "f793b169-1485-4d67-9c2c-1a5411910506",
                "startTime": "16:00",
                "endTime": "17:00",
                "maxCapacity": 2,
                "usedCapacity": 1
            }
        ]
    }
]
```

Si la capacidad del turno esta al maximo entonces se devuelve el siguiente error

```
{
    "status": 400,
    "errors": [
        "El turno ya se encuentra completo"
    ],
    "path": "/students",
    "timestamp": "08/02/2026"
}
```

En caso de que el turno NO este al maximo, pero uno de sus turnos especificos lo esta porque alumnos estan recuperando en ese turno y ocasiona que el turno este al maximo entonces:

```
{
    "status": 400,
    "errors": [
        "Uno o más turnos futuros ya se encuentran completos"
    ],
    "path": "/students",
    "timestamp": "08/02/2026"
}
```