### PR TITLE
[FIX][SLOT-234]: Arreglar el valor de la cantidad de elementos totales

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -162,7 +162,7 @@ public class StudentServiceImpl implements StudentService {
         return new PageImpl<>(
                 filteredContent,
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
-                filteredContent.size()
+                studentsPage.getTotalElements()
         );
     }
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -171,8 +171,7 @@ public class StudentServiceImpl implements StudentService {
         // we are filtering the content of the page, but the total elements of the page
         // still corresponds to the total elements without applying the student situation filter.
         // So we need to adjust the total elements of the page to correspond to the filtered content size.
-        long contentSize = status == null ? studentsPage.getTotalElements() : filteredContent.size();
-        return contentSize;
+        return status == null ? studentsPage.getTotalElements() : filteredContent.size();
     }
 
     private static List<StudentResponse> getContentByStudentSituationFilter(StudentSituation status, Page<StudentResponse> studentsPage) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -162,8 +162,17 @@ public class StudentServiceImpl implements StudentService {
         return new PageImpl<>(
                 filteredContent,
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
-                studentsPage.getTotalElements()
+                getContentSize(status, studentsPage, filteredContent)
         );
+    }
+
+    private static long getContentSize(StudentSituation status, Page<StudentResponse> studentsPage, List<StudentResponse> filteredContent) {
+        // This is because when we apply the student situation filter,
+        // we are filtering the content of the page, but the total elements of the page
+        // still corresponds to the total elements without applying the student situation filter.
+        // So we need to adjust the total elements of the page to correspond to the filtered content size.
+        long contentSize = status == null ? studentsPage.getTotalElements() : filteredContent.size();
+        return contentSize;
     }
 
     private static List<StudentResponse> getContentByStudentSituationFilter(StudentSituation status, Page<StudentResponse> studentsPage) {


### PR DESCRIPTION
Existía un bug que no se mostraba correctamente el número de elementos totales que existía, esto es porque no se estaba teniendo en cuenta el atibuto "totalElements" de la paginación cuando se obtenian los estudiantes, sino que solo se usaba el size de la lista "content", pero en esta lista al ser el contenido de una página, no significa que sea el numero total de elementos, sino la cantidad de elementos de esa página