### PR TITLE
[FIX][SLOT]: fix get inactive student

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
@@ -11,6 +11,7 @@ import com.three_tech_solutions.slot_app.data.models.*;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 public class StudentMapper {
@@ -50,10 +51,13 @@ public class StudentMapper {
         );
     }
 
-    public StudentDetailsResponse toStudentDetailsResponse(Student student, List<StudentSlotResponse> slots, Integer age) {
+    public StudentDetailsResponse toStudentDetailsResponse(
+            Student student,
+            List<StudentSlotResponse> slots,
+            Integer age
+    ) {
 
         PaymentPlan paymentPlan = student.getPaymentPlan();
-        Plan plan = paymentPlan != null ? paymentPlan.getPlan() : null;
 
         return new StudentDetailsResponse(
                 student.getId(),
@@ -65,13 +69,13 @@ public class StudentMapper {
                 age,
                 student.getPathologies(),
                 student.getAdmissionDate(),
-                paymentPlan != null ? paymentPlan.getPaymentPlanName().getName() : null,
-                plan != null ? plan.getName() : null,
-                plan != null ? plan.getNumberOfDays() : null,
-                paymentPlan != null ? paymentPlan.getPaymentDay() : null,
+                getValueOrNull(paymentPlan, p -> p.getPaymentPlanName().getName()),
+                getValueOrNull(paymentPlan, p -> p.getPlan().getName()),
+                getValueOrNull(paymentPlan, p -> p.getPlan().getNumberOfDays()),
+                getValueOrNull(paymentPlan, PaymentPlan::getPaymentDay),
                 student.isEnabled(),
                 student.getStudentSituation(),
-                plan != null ? plan.getId() : null,
+                getValueOrNull(paymentPlan, p -> p.getPlan().getId()),
                 slots
         );
     }
@@ -91,5 +95,9 @@ public class StudentMapper {
 
     private int getNumberOfSlotsToRecover(Student student) {
         return student.getAbsences().stream().filter(absence -> absence.getStatus() == AbsenceStatus.PENDING).toList().size();
+    }
+
+    private static <T, R> R getValueOrNull(T object, Function<T, R> accessor) {
+        return object != null ? accessor.apply(object) : null;
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
@@ -11,7 +11,8 @@ import com.three_tech_solutions.slot_app.data.models.*;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.function.Function;
+
+import static com.three_tech_solutions.slot_app.utils.NullSafeUtils.getValueOrNull;
 
 @Service
 public class StudentMapper {
@@ -97,7 +98,4 @@ public class StudentMapper {
         return student.getAbsences().stream().filter(absence -> absence.getStatus() == AbsenceStatus.PENDING).toList().size();
     }
 
-    private static <T, R> R getValueOrNull(T object, Function<T, R> accessor) {
-        return object != null ? accessor.apply(object) : null;
-    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/mappers/StudentMapper.java
@@ -51,6 +51,10 @@ public class StudentMapper {
     }
 
     public StudentDetailsResponse toStudentDetailsResponse(Student student, List<StudentSlotResponse> slots, Integer age) {
+
+        PaymentPlan paymentPlan = student.getPaymentPlan();
+        Plan plan = paymentPlan != null ? paymentPlan.getPlan() : null;
+
         return new StudentDetailsResponse(
                 student.getId(),
                 student.getName(),
@@ -61,13 +65,13 @@ public class StudentMapper {
                 age,
                 student.getPathologies(),
                 student.getAdmissionDate(),
-                student.getPaymentPlan().getPaymentPlanName().getName(),
-                student.getPaymentPlan().getPlan().getName(),
-                student.getPaymentPlan().getPlan().getNumberOfDays(),
-                student.getPaymentPlan().getPaymentDay(),
+                paymentPlan != null ? paymentPlan.getPaymentPlanName().getName() : null,
+                plan != null ? plan.getName() : null,
+                plan != null ? plan.getNumberOfDays() : null,
+                paymentPlan != null ? paymentPlan.getPaymentDay() : null,
                 student.isEnabled(),
                 student.getStudentSituation(),
-                student.getPaymentPlan().getPlan().getId(),
+                plan != null ? plan.getId() : null,
                 slots
         );
     }

--- a/src/main/java/com/three_tech_solutions/slot_app/utils/NullSafeUtils.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/utils/NullSafeUtils.java
@@ -1,0 +1,12 @@
+package com.three_tech_solutions.slot_app.utils;
+
+import java.util.function.Function;
+
+public final class NullSafeUtils {
+
+    private NullSafeUtils() {}
+
+    public static <T, R> R getValueOrNull(T object, Function<T, R> accessor) {
+        return object != null ? accessor.apply(object) : null;
+    }
+}


### PR DESCRIPTION
Al eliminar lógicamente un estudiante, cuando se hacía un GET del mismo se producía un error 500.
Esto ocurría porque el estudiante ya no contaba con paymentPlan asociado (se setea en null al darlo de baja), pero el mapper asumía que siempre existía un plan.
<img width="786" height="68" alt="image" src="https://github.com/user-attachments/assets/de630433-318a-40a2-b521-055fa98f9f49" />
<img width="576" height="202" alt="image" src="https://github.com/user-attachments/assets/d7d988b5-a3fd-4658-b277-a61bc3160854" />

Se ajustó el StudentMapper para contemplar correctamente los casos donde el estudiante no tiene plan asociado, evitando el NullPointerException:
<img width="617" height="419" alt="image" src="https://github.com/user-attachments/assets/7ee90aa3-dbee-4c1a-afe4-376bc57c2993" />
