### PR TITLE
[FIX][SLOT-235]: prevent inactive students from appearing in pending …

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -144,6 +144,10 @@ public class StudentServiceImpl implements StudentService {
 
     @Override
     public Page<StudentResponse> getStudentsByUserAndNameAndLastNameAndDni(User user, String filters, boolean filterByAbsences, StudentSituation status, Boolean isActive, Pageable pageable) {
+        if (filterByAbsences) {
+            isActive = true;
+        }
+        
         Page<StudentResponse> studentsPage = studentRepository
                 .getStudentsByUserAndFilters(user, filters, filterByAbsences, isActive, pageable)
                 .map(studentMapper::toStudentResponse);


### PR DESCRIPTION
Al obtener los alumnos que tienen parar recuperar clases, se devolvían alumnos que estan dados de baja.

Ahora, tengo 2 alumnas activas con recuperaciones pendientes:
<img width="615" height="474" alt="image" src="https://github.com/user-attachments/assets/3b2d0f17-6112-426f-8c20-bb6f77a71568" />

Al dar de baja a una alumna
<img width="786" height="88" alt="image" src="https://github.com/user-attachments/assets/5e500bd2-79a4-462b-bb89-a563f4f70b65" />

ya no me aparece al obtener los alumnos con recuepraciones pendientes
<img width="615" height="422" alt="image" src="https://github.com/user-attachments/assets/7ca7292e-8096-4e76-b1ba-39bd83f65afb" />
