### PR TITLE
[FIX][SLOT-115]: allow canceling specific slot even when no students …

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -57,23 +57,16 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
     public void cancelSpecificSlot(UUID specificSlotId, boolean studentsMustRecoverSlot) {
         SpecificSlot specificSlot = getSpecificSlotByIdOrThrowException(specificSlotId);
         validateIfSpecificSlotIsNotAlreadyCanceled(specificSlot);
-        List<SpecificSlotDetail> details = specificSlot.getSpecificSlotDetails();
-
-        if (studentsMustRecoverSlot && (details == null || details.isEmpty())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No hay estudiantes asignados para marcar con recuperación."
-            );
-        }
-
         if (studentsMustRecoverSlot) {
-            details.forEach(detail ->
-                    registerAbsenceForStudent(specificSlotId, detail)
-            );
+            specificSlot
+                    .getSpecificSlotDetails()
+                    .forEach(specificSlotDetail ->
+                            registerAbsenceForStudent(specificSlotId, specificSlotDetail)
+                    );
         }
 
         specificSlot.setStatus(CANCELED);
-        if (details != null) {
-            details.clear();
-        }
+        specificSlot.getSpecificSlotDetails().clear();
         specificSlotRepository.save(specificSlot);
     }
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -57,17 +57,23 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
     public void cancelSpecificSlot(UUID specificSlotId, boolean studentsMustRecoverSlot) {
         SpecificSlot specificSlot = getSpecificSlotByIdOrThrowException(specificSlotId);
         validateIfSpecificSlotIsNotAlreadyCanceled(specificSlot);
+        List<SpecificSlotDetail> details = specificSlot.getSpecificSlotDetails();
+
+        if (studentsMustRecoverSlot && (details == null || details.isEmpty())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No hay estudiantes asignados para marcar con recuperación."
+            );
+        }
 
         if (studentsMustRecoverSlot) {
-            specificSlot
-                    .getSpecificSlotDetails()
-                    .forEach(specificSlotDetail ->
-                            registerAbsenceForStudent(specificSlotId, specificSlotDetail)
-                    );
+            details.forEach(detail ->
+                    registerAbsenceForStudent(specificSlotId, detail)
+            );
         }
 
         specificSlot.setStatus(CANCELED);
-        specificSlot.setSpecificSlotDetails(Collections.emptyList());
+        if (details != null) {
+            details.clear();
+        }
         specificSlotRepository.save(specificSlot);
     }
 


### PR DESCRIPTION
Antes no se permitía cancelar un turno que no tenía estudiantes asignados.
Ahora se permite cancelar el turno sin importar si existen o no alumnos registrados:
<img width="423" height="45" alt="image" src="https://github.com/user-attachments/assets/5aa308fa-f0ec-4c3a-858e-38edc4b1f7ab" />
<img width="609" height="114" alt="image" src="https://github.com/user-attachments/assets/0f629beb-fb99-4f57-ba9e-57bba58e07f4" />
En el caso que se tengan que marcar los alumnos para que recuperen cuando se cancela un turno especific, decidí devolver un mensaje de error, porque en ese caso no se puede cumplir con la acción de registrarlos para recuperar. Me parecía inconsistente aceptar la request si una parte de lo que se está pidiendo no se hace. Si lo que se quiere es cancelar el turno sin generar recuperaciones, se puede hacer simplemente enviando el flag en false
De todas formas, si consideran que debería permitirse igual y simplemente ignorar las recuperaciones, lo vemos.
<img width="623" height="219" alt="image" src="https://github.com/user-attachments/assets/c34c7435-f223-43ff-9e60-a6ad97eaee87" />
