### PR TITLE
[FTR][SLOT-283]: Cronjob para crear los turnos del próximo mes

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/monthly_fee_processors/implementations/BeginningOfMonthMonthlyFeeProcessor.java
@@ -10,7 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDate;
 import java.time.Month;
 
-import static com.three_tech_solutions.slot_app.utils.PaymentPlanUtils.BEGINNING_OF_MONTH_EXPIRATION_DATE;
+import static com.three_tech_solutions.slot_app.constants.PaymentPlanConstants.BEGINNING_OF_MONTH_EXPIRATION_DATE;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Component

--- a/src/main/java/com/three_tech_solutions/slot_app/constants/PaymentPlanConstants.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/constants/PaymentPlanConstants.java
@@ -1,7 +1,7 @@
-package com.three_tech_solutions.slot_app.utils;
+package com.three_tech_solutions.slot_app.constants;
 
-public class PaymentPlanUtils {
-    private PaymentPlanUtils() {}
+public class PaymentPlanConstants {
+    private PaymentPlanConstants() {}
 
     public static final int BEGINNING_OF_MONTH_EXPIRATION_DATE = 10;
     public static final int SPECIFIC_DAY_MINIMUM_DAY = 10;

--- a/src/main/java/com/three_tech_solutions/slot_app/constants/SlotConstants.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/constants/SlotConstants.java
@@ -1,0 +1,14 @@
+package com.three_tech_solutions.slot_app.constants;
+
+public class SlotConstants {
+    private SlotConstants() {}
+
+    /**
+     * Número de meses por adelantado para los cuales se crearán los slots específicos.
+     * Esto se utiliza en el proceso de creación de slots específicos próximos,
+     * donde se generan slots para un período futuro determinado.
+     * Al establecer este valor, se asegura que siempre haya una cantidad suficiente
+     * de slots disponibles para los usuarios en los próximos meses.
+     */
+    public static final int MONTHS_AHEAD = 6;
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateStudentsMonthlyFees.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateStudentsMonthlyFees.java
@@ -1,0 +1,55 @@
+package com.three_tech_solutions.slot_app.cron_jobs;
+
+import com.three_tech_solutions.slot_app.components.monthly_fee_processors.MonthlyFeeProcessor;
+import com.three_tech_solutions.slot_app.components.monthly_fee_processors.factory.MonthlyFeeProcessorFactory;
+import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
+import com.three_tech_solutions.slot_app.data.models.Student;
+import com.three_tech_solutions.slot_app.services.interfaces.MonthlyFeeService;
+import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class CreateStudentsMonthlyFees {
+
+    private final StudentService studentService;
+    private final MonthlyFeeProcessorFactory monthlyFeeProcessorFactory;
+    private final MonthlyFeeService monthlyFeeService;
+
+    @Transactional
+    @Scheduled(cron = "0 0 1 * * *")
+    public void createStudentsMonthlyFee() {
+        log.info("Iniciando proceso de creacion de pagos");
+        List<Student> students = studentService.getStudents();
+        students.forEach(student -> {
+            try {
+                MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
+                Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createStudentMonthlyFee(student, getMonthlyFeeNumber());
+                monthlyFee
+                        .ifPresentOrElse(
+                                mf -> {
+                                    monthlyFeeService.saveMonthlyFee(mf);
+                                    log.info("Pago creado para el estudiante {}", student);
+                                },
+                                () -> log.info("No se creó pago para el estudiante {}", student)
+                        );
+            } catch (Exception e) {
+                log.error("Hubo un error al crear el pago para el estudiante ", e);
+            }
+        });
+    }
+
+    private int getMonthlyFeeNumber() {
+        return monthlyFeeService.getLastMonthlyFeeNumber();
+    }
+
+
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateUpcomingSpecificSlots.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateUpcomingSpecificSlots.java
@@ -1,0 +1,52 @@
+package com.three_tech_solutions.slot_app.cron_jobs;
+
+import com.three_tech_solutions.slot_app.data.models.Slot;
+import com.three_tech_solutions.slot_app.data.models.User;
+import com.three_tech_solutions.slot_app.services.interfaces.UserService;
+import com.three_tech_solutions.slot_app.utils.DateUtils;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class CreateUpcomingSpecificSlots {
+
+    private final UserService userService;
+
+    @Transactional
+    @Scheduled(cron = "* * * * * *")
+    void createUpcomingSpecificSlots() {
+        log.info("Iniciando proceso de creación de slots específicos próximos");
+        List<User> users = userService.getUsers();
+        users.forEach(user -> {
+            try {
+                List<Slot> userSlots = user.getSlots();
+                userSlots.forEach(slot -> {
+                    LocalDate startDate = DateUtils.getNextDateWithSameDayOfWeek(slot.getLastSpecificSlotDate());
+                    LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+
+                    slot.addSpecificSlots(
+                            user.getUserPreferences().getSlotDurationMinutes(),
+                            user.getUserPreferences().getSlotCapacity(),
+                            user,
+                            startDate,
+                            endDate
+                    );
+
+                });
+
+                userService.saveUser(user);
+            } catch (Exception e) {
+                log.error("Hubo un error al crear los slots específicos para el usuario ", e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateUpcomingSpecificSlots.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/CreateUpcomingSpecificSlots.java
@@ -14,6 +14,8 @@ import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
+import static com.three_tech_solutions.slot_app.constants.SlotConstants.MONTHS_AHEAD;
+
 @Service
 @Slf4j
 @AllArgsConstructor
@@ -22,7 +24,7 @@ public class CreateUpcomingSpecificSlots {
     private final UserService userService;
 
     @Transactional
-    @Scheduled(cron = "* * * * * *")
+    @Scheduled(cron = "0 0 1 1 * *")
     void createUpcomingSpecificSlots() {
         log.info("Iniciando proceso de creación de slots específicos próximos");
         List<User> users = userService.getUsers();
@@ -31,7 +33,7 @@ public class CreateUpcomingSpecificSlots {
                 List<Slot> userSlots = user.getSlots();
                 userSlots.forEach(slot -> {
                     LocalDate startDate = DateUtils.getNextDateWithSameDayOfWeek(slot.getLastSpecificSlotDate());
-                    LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+                    LocalDate endDate = LocalDate.now().plusMonths(MONTHS_AHEAD).with(TemporalAdjusters.lastDayOfMonth());
 
                     slot.addSpecificSlots(
                             user.getUserPreferences().getSlotDurationMinutes(),

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/ExpirePendingAbsences.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/ExpirePendingAbsences.java
@@ -1,4 +1,4 @@
-package com.three_tech_solutions.slot_app.services.implementations;
+package com.three_tech_solutions.slot_app.cron_jobs;
 
 import com.three_tech_solutions.slot_app.data.enums.AbsenceStatus;
 import com.three_tech_solutions.slot_app.data.models.Absence;
@@ -16,7 +16,7 @@ import java.util.List;
 @Service
 @AllArgsConstructor
 @Slf4j
-public class AbsenceServiceImpl implements AbsenceService {
+public class ExpirePendingAbsences implements AbsenceService {
 
     private final AbsenceRepository absenceRepository;
 

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -1,11 +1,13 @@
 package com.three_tech_solutions.slot_app.data.models;
 
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 
 @Entity
@@ -30,13 +32,12 @@ public class Slot {
     @Id
     private UUID id = UUID.randomUUID();
 
-    public Slot(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, byte capacity, User user, List<SpecificSlot> specificSlots) {
+    public Slot(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, byte capacity, User user) {
         this.dayOfWeek = dayOfWeek;
         this.startTime = startTime;
         this.endTime = endTime;
         this.capacity = capacity;
         this.user = user;
-        this.specificSlots = specificSlots;
     }
 
     public void removeStudent(Student student) {
@@ -96,5 +97,74 @@ public class Slot {
         this.capacity = capacity;
         this.getFutureSpecificSlots()
                 .forEach(specificSlot -> specificSlot.setCapacity(capacity));
+    }
+
+
+    /**
+     * Method to add specific slots from a start date to an end date with a specific time and duration.
+     * It will create specific slots for each week between the start and end date.
+     * @param slotDurationMinutes duration of the slot in minutes
+     * @param slotCapacity capacity of the slot
+     * @param user the user owner of the slot
+     * @param startDate the start date of the slot creation period
+     * @param endDate the end date of the slot creation period
+     * @param startTime the start time of the slot
+     */
+    public void addSpecificSlots(
+            long slotDurationMinutes,
+            byte slotCapacity,
+            User user,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalTime startTime
+    ) {
+        List<SpecificSlot> newSpecificSlots = new ArrayList<>();
+        LocalDate date = getNextOrSameDateOfDayOfWeek(startDate);
+
+        while (dateIsWithinSlotCreationPeriod(date, endDate)) {
+            /*
+             * This is to evict create slots with a start time
+             * before now when the day of week is the same as today
+             */
+            if (slotTimeIsBeforeNow(startTime, date)) {
+                date = date.plusWeeks(1);
+                continue;
+            }
+
+            newSpecificSlots.add(buildSpecificSlot(startTime, date, slotCapacity, slotDurationMinutes, user));
+            date = date.plusWeeks(1);
+        }
+
+        this.specificSlots.addAll(newSpecificSlots);
+    }
+
+
+    private static boolean dateIsWithinSlotCreationPeriod(LocalDate date, LocalDate endDate) {
+        return date.isBefore(endDate) || date.isEqual(endDate);
+    }
+
+    private static boolean slotTimeIsBeforeNow(LocalTime startTime, LocalDate date) {
+        return date.isEqual(LocalDate.now()) && startTime.isBefore(LocalTime.now());
+    }
+
+    private SpecificSlot buildSpecificSlot(
+            LocalTime startTime,
+            LocalDate startDate,
+            byte slotCapacity,
+            long slotDurationMinutes,
+            User user
+    ) {
+        return new SpecificSlot(
+                startDate,
+                slotCapacity,
+                startTime,
+                startTime.plusMinutes(slotDurationMinutes),
+                user,
+                SpecificSlotStatus.CREATED
+        );
+    }
+
+    private static LocalDate getNextOrSameDateOfDayOfWeek(LocalDate date) {
+        return LocalDate.now().with(TemporalAdjusters.nextOrSame(date.getDayOfWeek()));
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -7,7 +7,6 @@ import lombok.*;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 
 @Entity
@@ -108,18 +107,16 @@ public class Slot {
      * @param user the user owner of the slot
      * @param startDate the start date of the slot creation period
      * @param endDate the end date of the slot creation period
-     * @param startTime the start time of the slot
      */
     public void addSpecificSlots(
             long slotDurationMinutes,
             byte slotCapacity,
             User user,
             LocalDate startDate,
-            LocalDate endDate,
-            LocalTime startTime
+            LocalDate endDate
     ) {
         List<SpecificSlot> newSpecificSlots = new ArrayList<>();
-        LocalDate date = getNextOrSameDateOfDayOfWeek(startDate);
+        LocalDate date = startDate;
 
         while (dateIsWithinSlotCreationPeriod(date, endDate)) {
             /*
@@ -164,7 +161,11 @@ public class Slot {
         );
     }
 
-    private static LocalDate getNextOrSameDateOfDayOfWeek(LocalDate date) {
-        return LocalDate.now().with(TemporalAdjusters.nextOrSame(date.getDayOfWeek()));
+    public LocalDate getLastSpecificSlotDate() {
+        return this.specificSlots
+                .stream()
+                .map(SpecificSlot::getSlotDate)
+                .max(LocalDate::compareTo)
+                .orElse(LocalDate.now());
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/MonthlyFeeServiceImpl.java
@@ -13,21 +13,17 @@ import com.three_tech_solutions.slot_app.data.models.Student;
 import com.three_tech_solutions.slot_app.data.repositories.MonthlyFeeRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.MonthlyFeeService;
 import com.three_tech_solutions.slot_app.services.interfaces.PaymentService;
-import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,40 +33,18 @@ import java.util.UUID;
 public class MonthlyFeeServiceImpl implements MonthlyFeeService {
 
     private final MonthlyFeeRepository monthlyFeeRepository;
-    private final StudentService studentService;
     private final MonthlyFeeProcessorFactory monthlyFeeProcessorFactory;
     private final PaymentService paymentService;
-
-    @Transactional
-    @Scheduled(cron = "0 0 1 * * *")
-    @Override
-    public void createStudentsMonthlyFee() {
-        log.info("Iniciando proceso de creacion de pagos");
-        List<Student> students = studentService.getStudents();
-        students.forEach(student -> {
-            try {
-                MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
-                Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createStudentMonthlyFee(student, getMonthlyFeeNumber());
-                monthlyFee
-                        .ifPresentOrElse(
-                                monthlyFeeRepository::save,
-                                () -> log.info("No se creó pago para el estudiante {}", student)
-                        );
-            } catch (Exception e) {
-                log.error("Hubo un error al crear el pago para el estudiante ", e);
-            }
-        });
-    }
 
     @Override
     public void createInitialMonthlyFee(Student student, InitialPaymentContext initialPaymentContext) {
         MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
         MonthlyFee monthlyFee = monthlyFeeProcessor.createInitialStudentPayment(
                 student,
-                getMonthlyFeeNumber(),
+                getLastMonthlyFeeNumber(),
                 initialPaymentContext
         );
-        monthlyFeeRepository.save(monthlyFee);
+        saveMonthlyFee(monthlyFee);
     }
 
     @Override
@@ -85,7 +59,7 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
 
         updateStatus(monthlyFee);
 
-        monthlyFeeRepository.save(monthlyFee);
+        saveMonthlyFee(monthlyFee);
     }
 
     @Override
@@ -98,9 +72,9 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
     @Override
     public StudentMonthlyFeeResponse createMonthlyFeeForStudent(Student student) {
         MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
-        Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createNextStudentMonthlyFee(student, getMonthlyFeeNumber());
+        Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createNextStudentMonthlyFee(student, getLastMonthlyFeeNumber());
         MonthlyFee savedMonthlyFee = monthlyFee
-                .map(monthlyFeeRepository::save)
+                .map(this::saveMonthlyFee)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "No se pudo crear la cuota para el estudiante"));
         return MonthlyFeeMapper.toStudentMonthlyFeeResponse(savedMonthlyFee);
     }
@@ -123,15 +97,21 @@ public class MonthlyFeeServiceImpl implements MonthlyFeeService {
         monthlyFeeRepository.delete(monthlyFee);
     }
 
+    @Override
+    public int getLastMonthlyFeeNumber() {
+        return monthlyFeeRepository.getLastMonthlyFeeNumber().orElse(0) + 1;
+    }
+
+    @Override
+    public MonthlyFee saveMonthlyFee(MonthlyFee monthlyFee) {
+        return monthlyFeeRepository.save(monthlyFee);
+    }
+
     private static Integer getMonthValue(String month) {
         return Optional
                 .ofNullable(month)
                 .map(m -> Month.valueOf(m.toUpperCase()).getValue())
                 .orElse(null);
-    }
-
-    private int getMonthlyFeeNumber() {
-        return monthlyFeeRepository.getLastMonthlyFeeNumber().orElse(0) + 1;
     }
 
     private void validateNotAlreadyPaid(MonthlyFee monthlyFee) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -16,6 +16,7 @@ import com.three_tech_solutions.slot_app.services.interfaces.SlotService;
 import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotService;
 import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
 import com.three_tech_solutions.slot_app.services.interfaces.UserService;
+import com.three_tech_solutions.slot_app.utils.DateUtils;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -26,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -216,17 +218,15 @@ public class SlotServiceImpl implements SlotService {
                 user
         );
 
-        LocalDate startDate = LocalDate.now();
-        LocalDate endDate = startDate.plusMonths(2);
-        LocalTime startTime = request.startTime();
+        LocalDate startDate = DateUtils.getNextOrSameDateOfDayOfWeek(request.dayOfWeek());
+        LocalDate endDate = startDate.plusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
 
         slot.addSpecificSlots(
             user.getUserPreferences().getSlotDurationMinutes(),
             user.getUserPreferences().getSlotCapacity(),
             user,
             startDate,
-            endDate,
-            startTime
+            endDate
         );
 
         return slot;

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -26,8 +26,6 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -210,75 +208,28 @@ public class SlotServiceImpl implements SlotService {
     }
 
     private Slot buildSlot(CreateSlotRequest request, User user) {
-        return new Slot(
+        Slot slot = new Slot(
                 request.dayOfWeek(),
                 request.startTime(),
                 calculateEndTime(user, request.startTime()),
                 user.getUserPreferences().getSlotCapacity(),
-                user,
-                createSpecificSlots(
-                        request,
-                        user.getUserPreferences().getSlotDurationMinutes(),
-                        user.getUserPreferences().getSlotCapacity(),
-                        user
-                )
+                user
         );
-    }
 
-    private List<SpecificSlot> createSpecificSlots(
-            CreateSlotRequest request,
-            long slotDurationMinutes,
-            byte slotCapacity,
-            User user
-    ) {
-        List<SpecificSlot> specificSlots = new ArrayList<>();
-        LocalDate date = getNextOrSameDateOfDayOfWeek(request);
-        LocalDate endDate = date.plusMonths(2);
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusMonths(2);
+        LocalTime startTime = request.startTime();
 
-        while (dateIsWithinSlotCreationPeriod(date, endDate)) {
-            /*
-             * This is to evict create slots with a start time
-             * before now when the day of week is the same as today
-             */
-            if (slotTimeIsBeforeNow(request, date)) {
-                date = date.plusWeeks(1);
-                continue;
-            }
-
-            specificSlots.add(buildSpecificSlot(request, date, slotCapacity, slotDurationMinutes, user));
-            date = date.plusWeeks(1);
-        }
-
-        return specificSlots;
-    }
-
-    private static boolean dateIsWithinSlotCreationPeriod(LocalDate date, LocalDate endDate) {
-        return date.isBefore(endDate) || date.isEqual(endDate);
-    }
-
-    private static boolean slotTimeIsBeforeNow(CreateSlotRequest request, LocalDate date) {
-        return date.isEqual(LocalDate.now()) && request.startTime().isBefore(LocalTime.now());
-    }
-
-    private SpecificSlot buildSpecificSlot(
-            CreateSlotRequest request,
-            LocalDate startDate,
-            byte slotCapacity,
-            long slotDurationMinutes,
-            User user
-    ) {
-        return new SpecificSlot(
-                startDate,
-                slotCapacity,
-                request.startTime(),
-                request.startTime().plusMinutes(slotDurationMinutes),
-                user,
-                SpecificSlotStatus.CREATED
+        slot.addSpecificSlots(
+            user.getUserPreferences().getSlotDurationMinutes(),
+            user.getUserPreferences().getSlotCapacity(),
+            user,
+            startDate,
+            endDate,
+            startTime
         );
-    }
 
-    private static LocalDate getNextOrSameDateOfDayOfWeek(CreateSlotRequest request) {
-        return LocalDate.now().with(TemporalAdjusters.nextOrSame(request.dayOfWeek()));
+        return slot;
     }
 
     private User getUserByIdOrThrowException(UUID userId) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.three_tech_solutions.slot_app.constants.SlotConstants.MONTHS_AHEAD;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -219,7 +220,7 @@ public class SlotServiceImpl implements SlotService {
         );
 
         LocalDate startDate = DateUtils.getNextOrSameDateOfDayOfWeek(request.dayOfWeek());
-        LocalDate endDate = startDate.plusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
+        LocalDate endDate = startDate.plusMonths(MONTHS_AHEAD).with(TemporalAdjusters.lastDayOfMonth());
 
         slot.addSpecificSlots(
             user.getUserPreferences().getSlotDurationMinutes(),

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.three_tech_solutions.slot_app.utils.PaymentPlanUtils.*;
+import static com.three_tech_solutions.slot_app.constants.PaymentPlanConstants.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/UserServiceImpl.java
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void createUser(String username, String password) {
         try {
-            userRepository.save(new User(
+            saveUser(new User(
                     username,
                     passwordEncoder.encode(password)
             ));
@@ -97,7 +97,7 @@ public class UserServiceImpl implements UserService {
         slotService.validateFutureSpecificSlotsCapacity(user, newCapacity);
         user.getUserPreferences().setSlotCapacity(newCapacity);
         updateSlotsAndSpecificSlotsCapacity(user, newCapacity);
-        userRepository.save(user);
+        saveUser(user);
     }
 
     @Override
@@ -117,6 +117,16 @@ public class UserServiceImpl implements UserService {
         return this.userRepository.findById(userId)
                 .map(userPreferencesMapper::toUserPreferencesResponse)
                 .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Hubo un error al encontrar el usuario"));
+    }
+
+    @Override
+    public List<User> getUsers() {
+        return this.userRepository.findAll();
+    }
+
+    @Override
+    public void saveUser(User user) {
+        this.userRepository.save(user);
     }
 
     private void updateSlotsAndSpecificSlotsCapacity(User user, byte newCapacity) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/MonthlyFeeService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/MonthlyFeeService.java
@@ -10,12 +10,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 
 public interface MonthlyFeeService {
 
-    void createStudentsMonthlyFee();
     void createInitialMonthlyFee(Student student, InitialPaymentContext initialPaymentContext);
     void payMonthlyFee(UUID monthlyFeeId);
     Page<StudentMonthlyFeeResponse> getMonthlyFeesByStudent(
@@ -30,4 +28,8 @@ public interface MonthlyFeeService {
     int findAssociatedMonthlyFeeNumber(Payment payment);
     MonthlyFee getMonthlyFeeById(UUID monthlyFeeId);
     void deleteMonthlyFee(MonthlyFee monthlyFee);
+
+    int getLastMonthlyFeeNumber();
+
+    MonthlyFee saveMonthlyFee(MonthlyFee monthlyFee);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/UserService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/UserService.java
@@ -35,4 +35,8 @@ public interface UserService extends UserDetailsService {
     CalendarResponse getCalendar(UUID userId, CalendarViewType viewType, LocalDate date);
 
     UserPreferencesResponse getUserPreferences(@PathVariable UUID userId);
+
+    List<User> getUsers();
+
+    void saveUser(User user);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/utils/DateUtils.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/utils/DateUtils.java
@@ -1,0 +1,19 @@
+package com.three_tech_solutions.slot_app.utils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+public class DateUtils {
+    private DateUtils() {
+
+    }
+
+    public static LocalDate getNextOrSameDateOfDayOfWeek(DayOfWeek dayOfWeek) {
+        return LocalDate.now().with(TemporalAdjusters.nextOrSame(dayOfWeek));
+    }
+
+    public static LocalDate getNextDateWithSameDayOfWeek(LocalDate date) {
+        return date.with(TemporalAdjusters.next(date.getDayOfWeek()));
+    }
+}


### PR DESCRIPTION
Se realizaron varios cambios:

1. Refactoricé la creación de los turnos específicos para que esté encapsulada en la entidad `Slot`, de esta manera es reutilizable y solo hay que indicarle al Slot desde que fecha hasta que fecha tiene que crear los turnos específicos (y algunos datos más). Así se puede reutilizar tanto para cuando creamos un turno como para cuando se ejecuta el cronjob
2. Como estábamos teniendo varios cronjob (y van a seguir creandose) decidí crear un package específico de cronjob y moví los que teniamos a ese package. Ahora cada cronjob es una clase en particular
3. Agregué la logica necesaria para la creación de los turnos del proximo mes (segun el ultimo creado que tenga el slot)