### PR TITLE
[FTR][SLOT-285]: Agregar auditoria a los cronjobs

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/CreateStudentsMonthlyFees.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/CreateStudentsMonthlyFees.java
@@ -1,16 +1,19 @@
-package com.three_tech_solutions.slot_app.cron_jobs;
+package com.three_tech_solutions.slot_app.cron_jobs.components;
 
 import com.three_tech_solutions.slot_app.components.monthly_fee_processors.MonthlyFeeProcessor;
 import com.three_tech_solutions.slot_app.components.monthly_fee_processors.factory.MonthlyFeeProcessorFactory;
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+import com.three_tech_solutions.slot_app.cron_jobs.services.interfaces.CronJobAuditoryService;
 import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
 import com.three_tech_solutions.slot_app.data.models.Student;
 import com.three_tech_solutions.slot_app.services.interfaces.MonthlyFeeService;
 import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,14 +26,16 @@ public class CreateStudentsMonthlyFees {
     private final StudentService studentService;
     private final MonthlyFeeProcessorFactory monthlyFeeProcessorFactory;
     private final MonthlyFeeService monthlyFeeService;
+    private final CronJobAuditoryService cronJobAuditoryService;
 
     @Transactional
     @Scheduled(cron = "0 0 1 * * *")
     public void createStudentsMonthlyFee() {
         log.info("Iniciando proceso de creacion de pagos");
-        List<Student> students = studentService.getStudents();
-        students.forEach(student -> {
-            try {
+        CronJobAuditory cronJobAuditory = cronJobAuditoryService.createCronJobExecution(CronJobType.CREATE_STUDENTS_MONTHLY_FEES);
+        try {
+            List<Student> students = studentService.getStudents();
+            students.forEach(student -> {
                 MonthlyFeeProcessor monthlyFeeProcessor = monthlyFeeProcessorFactory.getPaymentProcessor(student.getPaymentPlan().getPaymentPlanName());
                 Optional<MonthlyFee> monthlyFee = monthlyFeeProcessor.createStudentMonthlyFee(student, getMonthlyFeeNumber());
                 monthlyFee
@@ -41,10 +46,13 @@ public class CreateStudentsMonthlyFees {
                                 },
                                 () -> log.info("No se creó pago para el estudiante {}", student)
                         );
-            } catch (Exception e) {
-                log.error("Hubo un error al crear el pago para el estudiante ", e);
-            }
-        });
+            });
+            cronJobAuditoryService.setCronJobExecutionSuccess(cronJobAuditory);
+        } catch (Exception e) {
+            log.error("Hubo un error al crear los pagos de los estudiantes", e);
+            cronJobAuditoryService.setCronJobExecutionFailure(cronJobAuditory, e.getMessage());
+            throw e;
+        }
     }
 
     private int getMonthlyFeeNumber() {

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/CreateUpcomingSpecificSlots.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/CreateUpcomingSpecificSlots.java
@@ -1,14 +1,17 @@
-package com.three_tech_solutions.slot_app.cron_jobs;
+package com.three_tech_solutions.slot_app.cron_jobs.components;
 
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+import com.three_tech_solutions.slot_app.cron_jobs.services.interfaces.CronJobAuditoryService;
 import com.three_tech_solutions.slot_app.data.models.Slot;
 import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.services.interfaces.UserService;
 import com.three_tech_solutions.slot_app.utils.DateUtils;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
@@ -19,15 +22,17 @@ import java.util.List;
 @AllArgsConstructor
 public class CreateUpcomingSpecificSlots {
 
+    private final CronJobAuditoryService cronJobAuditoryService;
     private final UserService userService;
 
     @Transactional
-    @Scheduled(cron = "* * * * * *")
+    @Scheduled(cron = "0 0 1 1 * *")
     void createUpcomingSpecificSlots() {
         log.info("Iniciando proceso de creación de slots específicos próximos");
-        List<User> users = userService.getUsers();
-        users.forEach(user -> {
-            try {
+        CronJobAuditory cronJobAuditory = cronJobAuditoryService.createCronJobExecution(CronJobType.CREATE_UPCOMING_SPECIFIC_SLOTS);
+        try {
+            List<User> users = userService.getUsers();
+            users.forEach(user -> {
                 List<Slot> userSlots = user.getSlots();
                 userSlots.forEach(slot -> {
                     LocalDate startDate = DateUtils.getNextDateWithSameDayOfWeek(slot.getLastSpecificSlotDate());
@@ -42,11 +47,13 @@ public class CreateUpcomingSpecificSlots {
                     );
 
                 });
-
                 userService.saveUser(user);
-            } catch (Exception e) {
-                log.error("Hubo un error al crear los slots específicos para el usuario ", e);
-            }
-        });
+            });
+            cronJobAuditoryService.setCronJobExecutionSuccess(cronJobAuditory);
+        } catch (Exception e) {
+            log.error("Hubo un error al crear los slots específicos", e);
+            cronJobAuditoryService.setCronJobExecutionFailure(cronJobAuditory, e.getMessage());
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/ExpirePendingAbsences.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/components/ExpirePendingAbsences.java
@@ -1,14 +1,17 @@
-package com.three_tech_solutions.slot_app.cron_jobs;
+package com.three_tech_solutions.slot_app.cron_jobs.components;
 
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+import com.three_tech_solutions.slot_app.cron_jobs.services.interfaces.CronJobAuditoryService;
 import com.three_tech_solutions.slot_app.data.enums.AbsenceStatus;
 import com.three_tech_solutions.slot_app.data.models.Absence;
 import com.three_tech_solutions.slot_app.data.repositories.AbsenceRepository;
 import com.three_tech_solutions.slot_app.services.interfaces.AbsenceService;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,6 +21,7 @@ import java.util.List;
 @Slf4j
 public class ExpirePendingAbsences implements AbsenceService {
 
+    private final CronJobAuditoryService cronJobAuditoryService;
     private final AbsenceRepository absenceRepository;
 
     @Transactional
@@ -25,14 +29,22 @@ public class ExpirePendingAbsences implements AbsenceService {
     @Override
     public void expirePendingAbsences() {
         log.info("Iniciando proceso de expiración de ausencias");
-        LocalDate today = LocalDate.now();
+        CronJobAuditory cronJobAuditory = cronJobAuditoryService.createCronJobExecution(CronJobType.EXPIRE_PENDING_ABSENCES);
+        try {
+            LocalDate today = LocalDate.now();
 
-        List<Absence> absencesToExpire = getPendingAbsences().stream()
-                .filter(absence -> shouldExpireAbsence(absence, today))
-                .peek(absence -> absence.setStatus(AbsenceStatus.OUT_OF_TIME))
-                .toList();
+            List<Absence> absencesToExpire = getPendingAbsences().stream()
+                    .filter(absence -> shouldExpireAbsence(absence, today))
+                    .peek(absence -> absence.setStatus(AbsenceStatus.OUT_OF_TIME))
+                    .toList();
 
-        absenceRepository.saveAll(absencesToExpire);
+            absenceRepository.saveAll(absencesToExpire);
+            cronJobAuditoryService.setCronJobExecutionSuccess(cronJobAuditory);
+        } catch (Exception e) {
+            log.error("Hubo un error al expirar las ausencias pendientes", e);
+            cronJobAuditoryService.setCronJobExecutionFailure(cronJobAuditory, e.getMessage());
+            throw e;
+        }
     }
 
     private boolean shouldExpireAbsence(Absence absence, LocalDate today) {

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/enums/CronJobStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/enums/CronJobStatus.java
@@ -1,0 +1,7 @@
+package com.three_tech_solutions.slot_app.cron_jobs.data.enums;
+
+public enum CronJobStatus {
+    STARTED,
+    ERROR,
+    COMPLETED
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/enums/CronJobType.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/enums/CronJobType.java
@@ -1,0 +1,17 @@
+package com.three_tech_solutions.slot_app.cron_jobs.data.enums;
+
+public enum CronJobType {
+    CREATE_UPCOMING_SPECIFIC_SLOTS("create_upcoming_specific_slots"),
+    EXPIRE_PENDING_ABSENCES("expire_pending_absences"),
+    CREATE_STUDENTS_MONTHLY_FEES("create_students_monthly_fees");
+
+    private final String value;
+
+    CronJobType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/models/CronJobAuditory.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/models/CronJobAuditory.java
@@ -1,0 +1,50 @@
+package com.three_tech_solutions.slot_app.cron_jobs.data.models;
+
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobStatus;
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor
+@Data
+@AllArgsConstructor
+public class CronJobAuditory {
+
+    @Enumerated(EnumType.STRING)
+    CronJobType cronJobType;
+    @OneToMany(cascade = CascadeType.ALL)
+    List<CronJobStatusHistory> statusHistory;
+    LocalDateTime cronJobUpdatedAt = LocalDateTime.now();
+    LocalDateTime cronJobStartedAt = LocalDateTime.now();
+    @Id
+    UUID id = UUID.randomUUID();
+
+    public CronJobAuditory(CronJobType cronJobType) {
+        this.cronJobType = cronJobType;
+        this.statusHistory = new ArrayList<>(
+                List.of(new CronJobStatusHistory(CronJobStatus.STARTED) )
+        );
+    }
+
+    public void addStatus(CronJobStatus cronJobStatus) {
+        this.cronJobUpdatedAt = LocalDateTime.now();
+        this.statusHistory.add(
+                new CronJobStatusHistory(cronJobStatus)
+        );
+    }
+
+    public void addStatus(CronJobStatus cronJobStatus, String description) {
+        this.cronJobUpdatedAt = LocalDateTime.now();
+        this.statusHistory.add(
+                new CronJobStatusHistory(cronJobStatus, description)
+        );
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/models/CronJobStatusHistory.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/models/CronJobStatusHistory.java
@@ -1,0 +1,33 @@
+package com.three_tech_solutions.slot_app.cron_jobs.data.models;
+
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class CronJobStatusHistory {
+    String description;
+    @Enumerated(EnumType.STRING)
+    CronJobStatus status;
+    LocalDateTime createdAt = LocalDateTime.now();
+    @Id
+    UUID id = UUID.randomUUID();
+
+    public CronJobStatusHistory(CronJobStatus status) {
+        this.status = status;
+    }
+
+    public CronJobStatusHistory(CronJobStatus status, String description) {
+        this.status = status;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/repositories/CronJobAuditoryRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/data/repositories/CronJobAuditoryRepository.java
@@ -1,0 +1,9 @@
+package com.three_tech_solutions.slot_app.cron_jobs.data.repositories;
+
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CronJobAuditoryRepository extends JpaRepository<CronJobAuditory, UUID> {
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/services/implementations/CronJobAuditoryServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/services/implementations/CronJobAuditoryServiceImpl.java
@@ -1,0 +1,45 @@
+package com.three_tech_solutions.slot_app.cron_jobs.services.implementations;
+
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobStatus;
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+import com.three_tech_solutions.slot_app.cron_jobs.data.repositories.CronJobAuditoryRepository;
+import com.three_tech_solutions.slot_app.cron_jobs.services.interfaces.CronJobAuditoryService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+@Component
+@AllArgsConstructor
+@Transactional(propagation = REQUIRES_NEW)
+public class CronJobAuditoryServiceImpl implements CronJobAuditoryService {
+    private final CronJobAuditoryRepository cronJobAuditoryRepository;
+
+    @Override
+    public CronJobAuditory createCronJobExecution(CronJobType cronJobType) {
+        return saveCronJob(
+                new CronJobAuditory(cronJobType)
+        );
+    }
+
+    @Override
+    public void setCronJobExecutionSuccess(CronJobAuditory cronJobAuditory) {
+        cronJobAuditory.addStatus(CronJobStatus.COMPLETED);
+        saveCronJob(cronJobAuditory);
+    }
+
+    @Override
+    public void setCronJobExecutionFailure(CronJobAuditory cronJobAuditory, String errorMessage) {
+        cronJobAuditory.addStatus(CronJobStatus.ERROR, errorMessage);
+        saveCronJob(cronJobAuditory);
+    }
+
+
+    private CronJobAuditory saveCronJob(CronJobAuditory cronJobAuditory) {
+        return this.cronJobAuditoryRepository.save(
+                cronJobAuditory
+        );
+    }
+}

--- a/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/services/interfaces/CronJobAuditoryService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/cron_jobs/services/interfaces/CronJobAuditoryService.java
@@ -1,0 +1,12 @@
+package com.three_tech_solutions.slot_app.cron_jobs.services.interfaces;
+
+import com.three_tech_solutions.slot_app.cron_jobs.data.enums.CronJobType;
+import com.three_tech_solutions.slot_app.cron_jobs.data.models.CronJobAuditory;
+
+public interface CronJobAuditoryService {
+    CronJobAuditory createCronJobExecution(CronJobType cronJobType);
+
+    void setCronJobExecutionSuccess(CronJobAuditory cronJobAuditory);
+
+    void setCronJobExecutionFailure(CronJobAuditory cronJobAuditory, String message);
+}


### PR DESCRIPTION
Para tener un mayor control de los cronjobs agregué estas clases y servicios para auditarlos, de manera que podamos saber cuándo se completan, fallan y por qué