### PR TITLE
[FTR][SLOT-266]: Modify plansResponse to include nextPrice, futurePri…

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PlanResponse.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PlanResponse.java
@@ -9,5 +9,6 @@ public record PlanResponse(
         double currentPrice,
         PriceResponse nextPrice,
         List<PriceResponse> futurePrices,
-        int numberOfDays
+        int numberOfDays,
+        int totalFuturePrices
 ) { }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PlanResponse.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PlanResponse.java
@@ -1,10 +1,13 @@
 package com.three_tech_solutions.slot_app.controllers.responses;
 
+import java.util.List;
 import java.util.UUID;
 
 public record PlanResponse(
         UUID id,
         String name,
-        double price,
+        double currentPrice,
+        PriceResponse nextPrice,
+        List<PriceResponse> futurePrices,
         int numberOfDays
 ) { }

--- a/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PriceResponse.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/controllers/responses/PriceResponse.java
@@ -1,9 +1,12 @@
 package com.three_tech_solutions.slot_app.controllers.responses;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public record PriceResponse(
     UUID id,
-    double amount
+    LocalDate startDate,
+    double amount,
+    int daysUntilActive
 ) {
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/mappers/PriceMapper.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/mappers/PriceMapper.java
@@ -4,12 +4,14 @@ import com.three_tech_solutions.slot_app.controllers.responses.PriceResponse;
 import com.three_tech_solutions.slot_app.data.models.Price;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Component
 public class PriceMapper {
     public PriceResponse toPriceResponse(Price price) {
-        return new PriceResponse(price.getId(), price.getAmount());
+        return new PriceResponse(price.getId(), price.getStartDate(), price.getAmount(), price.getDaysUntilActive());
     }
 
     public List<PriceResponse> toPriceResponseList(List<Price> price) {

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
@@ -4,17 +4,13 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
-
 
 @Entity
 @Data
@@ -32,15 +28,12 @@ public class Plan {
     @Id
     UUID id = UUID.randomUUID();
 
-
-
     public Plan(String name, byte numberOfDays, List<Price> prices, User user) {
         this.name = name;
         this.numberOfDays = numberOfDays;
         this.prices = prices;
         this.user = user;
     }
-
 
     public Price getCurrentPrice() {
         LocalDate  today = LocalDate.now();
@@ -51,24 +44,23 @@ public class Plan {
                 .orElseThrow(() -> new ResponseStatusException(INTERNAL_SERVER_ERROR, "Hubo un error al obtener los precios de los planes"));
     }
 
-    public Optional <Price> getNextPrice (){
+    public Optional<Price> getNextPrice(){
         Price current = getCurrentPrice();
         return this.getPrices()
                 .stream()
-                .filter(price -> priceIsAfterCurrentPrice(current, price))
+                .filter(price -> startsAfter(current, price))
                 .min(Comparator.comparing(price -> price.startDate));
     }
 
-    public List <Price> getFuturePrices(){
+    public List<Price> getFuturePrices(){
         return getNextPrice()
                 .map(nextPrice -> this.getPrices()
                         .stream()
-                        .filter(price -> price.startDate.isAfter(nextPrice.startDate))
+                        .filter(price -> startsAfter(nextPrice, price))
                         .sorted(Comparator.comparing(price -> price.startDate))
                         .collect(Collectors.toList()))
                 .orElse(List.of());
     }
-
 
     private static boolean priceEndDateIsNullOrIsAfterToday(Price price, LocalDate today) {
         /*
@@ -78,10 +70,9 @@ public class Plan {
         return price.endDate == null || today.isBefore(price.endDate);
     }
 
-    private boolean priceIsAfterCurrentPrice (Price currentPrice, Price price){
-        return currentPrice.startDate.isBefore(price.startDate);
+    private boolean startsAfter(Price first, Price second){
+        return first.startDate.isBefore(second.startDate);
     }
-
 
     private static boolean priceStartDateIsBeforeOrEqualThanToday(Price price, LocalDate today) {
         return price.startDate.isBefore(today) || price.startDate.isEqual(today);

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
@@ -6,10 +6,15 @@ import lombok.NoArgsConstructor;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+
 
 @Entity
 @Data
@@ -27,12 +32,15 @@ public class Plan {
     @Id
     UUID id = UUID.randomUUID();
 
+
+
     public Plan(String name, byte numberOfDays, List<Price> prices, User user) {
         this.name = name;
         this.numberOfDays = numberOfDays;
         this.prices = prices;
         this.user = user;
     }
+
 
     public Price getCurrentPrice() {
         LocalDate  today = LocalDate.now();
@@ -43,6 +51,25 @@ public class Plan {
                 .orElseThrow(() -> new ResponseStatusException(INTERNAL_SERVER_ERROR, "Hubo un error al obtener los precios de los planes"));
     }
 
+    public Optional <Price> getNextPrice (){
+        Price current = getCurrentPrice();
+        return this.getPrices()
+                .stream()
+                .filter(price -> priceIsAfterCurrentPrice(current, price))
+                .min(Comparator.comparing(price -> price.startDate));
+    }
+
+    public List <Price> getFuturePrices(){
+        return getNextPrice()
+                .map(nextPrice -> this.getPrices()
+                        .stream()
+                        .filter(price -> price.startDate.isAfter(nextPrice.startDate))
+                        .sorted(Comparator.comparing(price -> price.startDate))
+                        .collect(Collectors.toList()))
+                .orElse(List.of());
+    }
+
+
     private static boolean priceEndDateIsNullOrIsAfterToday(Price price, LocalDate today) {
         /*
             We validate endDate as null because the first price of the plan when we create it
@@ -50,6 +77,11 @@ public class Plan {
          */
         return price.endDate == null || today.isBefore(price.endDate);
     }
+
+    private boolean priceIsAfterCurrentPrice (Price currentPrice, Price price){
+        return currentPrice.startDate.isBefore(price.startDate);
+    }
+
 
     private static boolean priceStartDateIsBeforeOrEqualThanToday(Price price, LocalDate today) {
         return price.startDate.isBefore(today) || price.startDate.isEqual(today);

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Plan.java
@@ -62,6 +62,10 @@ public class Plan {
                 .orElse(List.of());
     }
 
+    public int calculateTotalFuturePrices(List<Price> futurePrices, Optional<Price> nextPrice) {
+        return nextPrice.map(np -> futurePrices.size() + 1).orElse(0);
+    }
+
     private static boolean priceEndDateIsNullOrIsAfterToday(Price price, LocalDate today) {
         /*
             We validate endDate as null because the first price of the plan when we create it

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Price.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Price.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 @Entity
@@ -24,5 +25,9 @@ public class Price {
     public Price(double amount, LocalDate startDate) {
         this.amount = amount;
         this.startDate = startDate;
+    }
+
+    public int getDaysUntilActive() {
+        return (int) ChronoUnit.DAYS.between(LocalDate.now(), this.startDate);
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
@@ -3,6 +3,8 @@ package com.three_tech_solutions.slot_app.services.implementations;
 import com.three_tech_solutions.slot_app.controllers.requests.CreatePlanRequest;
 import com.three_tech_solutions.slot_app.controllers.requests.UpdatePlanRequest;
 import com.three_tech_solutions.slot_app.controllers.responses.PlanResponse;
+import com.three_tech_solutions.slot_app.controllers.responses.PriceResponse;
+import com.three_tech_solutions.slot_app.data.mappers.PriceMapper;
 import com.three_tech_solutions.slot_app.data.models.Plan;
 import com.three_tech_solutions.slot_app.data.models.Price;
 import com.three_tech_solutions.slot_app.data.models.User;
@@ -20,6 +22,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
@@ -28,10 +31,13 @@ public class PlanServiceImpl implements PlanService {
 
     private final UserService userService;
     private final PlanRepository planRepository;
+    private final PriceMapper priceMapper;
 
-    public PlanServiceImpl(@Lazy UserService userService, PlanRepository planRepository) {
+
+    public PlanServiceImpl(@Lazy UserService userService, PlanRepository planRepository, PriceMapper priceMapper) {
         this.userService = userService;
         this.planRepository = planRepository;
+        this.priceMapper = priceMapper;
     }
 
     @Override
@@ -135,11 +141,15 @@ public class PlanServiceImpl implements PlanService {
         );
     }
 
-    private static PlanResponse buildPlanResponse(Plan plan) {
+    private PlanResponse buildPlanResponse(Plan plan) {
         return new PlanResponse(
                 plan.getId(),
                 plan.getName(),
                 plan.getCurrentPrice().getAmount(),
+                plan.getNextPrice()
+                        .map(priceMapper::toPriceResponse)
+                        .orElse(null),
+                priceMapper.toPriceResponseList(plan.getFuturePrices()),
                 plan.getNumberOfDays()
         );
     }
@@ -161,7 +171,7 @@ public class PlanServiceImpl implements PlanService {
     private Page<PlanResponse> getPlansFromRepository(User user, String planName, Pageable pageable, List<Sort.Order> sorts) {
         return this.planRepository
                 .findAllByUserAndPlanName(user, planName, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(sorts)))
-                .map(PlanServiceImpl::buildPlanResponse);
+                .map(this::buildPlanResponse);
     }
 
     private List<Sort.Order> removePriceSortFromPageableSorts(Pageable pageable) {
@@ -189,10 +199,11 @@ public class PlanServiceImpl implements PlanService {
     }
 
     private Stream<PlanResponse> getPlansSortedByPriceDesc(Stream<PlanResponse> plansSortedByPrice) {
-        return plansSortedByPrice.sorted(Comparator.comparingDouble(PlanResponse::price).reversed());
+        return plansSortedByPrice.sorted(Comparator.comparingDouble(PlanResponse::currentPrice).reversed());
     }
 
     private Stream<PlanResponse> getPlansSortedByPriceAsc(Stream<PlanResponse> plansSortedByPrice) {
-        return plansSortedByPrice.sorted(Comparator.comparingDouble(PlanResponse::price));
+        return plansSortedByPrice.sorted(Comparator.comparingDouble(PlanResponse::currentPrice));
     }
+
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/PlanServiceImpl.java
@@ -150,7 +150,8 @@ public class PlanServiceImpl implements PlanService {
                         .map(priceMapper::toPriceResponse)
                         .orElse(null),
                 priceMapper.toPriceResponseList(plan.getFuturePrices()),
-                plan.getNumberOfDays()
+                plan.getNumberOfDays(),
+                plan.calculateTotalFuturePrices(plan.getFuturePrices(), plan.getNextPrice())
         );
     }
 
@@ -178,12 +179,12 @@ public class PlanServiceImpl implements PlanService {
         return pageable
                 .getSort()
                 .stream()
-                .filter(order -> !order.getProperty().equalsIgnoreCase("price"))
+                .filter(order -> !order.getProperty().equalsIgnoreCase("currentPrice"))
                 .toList();
     }
 
     private List<PlanResponse> sortPlansByPriceIfNecessary(Pageable pageable, Stream<PlanResponse> plansSortedByPrice) {
-        Sort.Order priceSortOrder = pageable.getSort().getOrderFor("price");
+        Sort.Order priceSortOrder = pageable.getSort().getOrderFor("currentPrice");
         if (mustSortByPrice(priceSortOrder)) {
             plansSortedByPrice = sortPriceIsDesc(priceSortOrder) ? getPlansSortedByPriceDesc(plansSortedByPrice) : getPlansSortedByPriceAsc(plansSortedByPrice);
         }


### PR DESCRIPTION
Modifiqué la response de planes para incluir:

- nextPrice (sería el próximo precio a ser vigente), con sus respectivos atributos
- lista de futurePrices (precios futuros sin incluir el próximo precio)
 
También modifiqué la response de price para agregar el atributo daysUntilActive que nos indica cuántos días faltan para que el precio pase a estar activo.

Tengo la duda de si agregar también la cantidad de precios futuros + 1 en la response, o directamente hacemos el cálculo desde el front (esto sería el número que mostramos al lado de 'Próximo precio' en la tabla

El modelo debe adaptarse a estas pantallas:
<img width="452" height="311" alt="image" src="https://github.com/user-attachments/assets/5af5d47f-d4d0-4d4f-9a68-8de4a3781ea1" />
<img width="797" height="449" alt="image" src="https://github.com/user-attachments/assets/c54a0b98-ba90-4d79-a8c1-f4da62f5c9f1" />

