### PR TITLE
[FTR][SLOT-255]: change the specific slots status to finished

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/SlotAppApplication.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/SlotAppApplication.java
@@ -2,10 +2,12 @@ package com.three_tech_solutions.slot_app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class SlotAppApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
@@ -3,6 +3,5 @@ package com.three_tech_solutions.slot_app.data.enums;
 public enum SpecificSlotStatus {
     CREATED,
     CANCELED,
-    DELETED,
     FINISHED
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/SpecificSlotStatus.java
@@ -3,5 +3,6 @@ package com.three_tech_solutions.slot_app.data.enums;
 public enum SpecificSlotStatus {
     CREATED,
     CANCELED,
-    DELETED
+    DELETED,
+    FINISHED
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/Slot.java
@@ -42,7 +42,7 @@ public class Slot {
     public void removeStudent(Student student) {
         this.students.remove(student);
         this.specificSlots
-                .stream().filter(Slot::isFutureSpecificSlot)
+                .stream().filter(SpecificSlot::isFutureSpecificSlot)
                 .forEach(specificSlot ->
                         specificSlot
                             .getSpecificSlotDetails()
@@ -54,7 +54,7 @@ public class Slot {
         this.getStudents().add(student);
         this.getSpecificSlots()
                 .stream()
-                .filter(Slot::isFutureSpecificSlot)
+                .filter(SpecificSlot::isFutureSpecificSlot)
                 .forEach(specificSlot -> {
                     List<SpecificSlotDetail> slotDetails = specificSlot.getSpecificSlotDetails();
                     slotDetails.add(new SpecificSlotDetail(student));
@@ -63,22 +63,14 @@ public class Slot {
 
     public List<SpecificSlot> getFutureSpecificSlots() {
         return this.specificSlots.stream()
-                .filter(Slot::isFutureSpecificSlot)
+                .filter(SpecificSlot::isFutureSpecificSlot)
                 .toList();
     }
 
     public boolean hasAtLeastOneStudentRegisted() {
         return this.specificSlots.stream()
-                .filter(Slot::isFutureSpecificSlot)
+                .filter(SpecificSlot::isFutureSpecificSlot)
                 .anyMatch(SpecificSlot::hasStudentsThatGoToSlot);
-    }
-
-    private static boolean isFutureSpecificSlot(SpecificSlot specificSlot) {
-        LocalDate today = LocalDate.now();
-        LocalTime now = LocalTime.now();
-
-        return specificSlot.getSlotDate().isAfter(today)
-                || (specificSlot.getSlotDate().isEqual(today) && specificSlot.getStartTime().isAfter(now));
     }
 
     public boolean isAtFullCapacity() {

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -64,4 +64,20 @@ public class SpecificSlot {
     public boolean isAtFullCapacity() {
         return this.capacity == this.getSpecificSlotUsedCapacity();
     }
+
+    public boolean isFutureSpecificSlot() {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        return this.slotDate.isAfter(today)
+                || (this.slotDate.isEqual(today) && this.startTime.isAfter(now));
+    }
+
+    public boolean hasFinished() {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        return this.slotDate.isBefore(today)
+                || (this.slotDate.isEqual(today) && this.endTime.isBefore(now));
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/models/SpecificSlot.java
@@ -80,4 +80,13 @@ public class SpecificSlot {
         return this.slotDate.isBefore(today)
                 || (this.slotDate.isEqual(today) && this.endTime.isBefore(now));
     }
+
+    public boolean finish() {
+        if (this.status == SpecificSlotStatus.CREATED && hasFinished()) {
+            this.status = SpecificSlotStatus.FINISHED;
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SpecificSlotRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/SpecificSlotRepository.java
@@ -1,5 +1,6 @@
 package com.three_tech_solutions.slot_app.data.repositories;
 
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,4 +23,19 @@ public interface SpecificSlotRepository extends JpaRepository<SpecificSlot, UUID
         ORDER BY s.slotDate, s.startTime
         """)
     List<SpecificSlot> findAllByUserAndSlotDateBetween(User user, LocalDate startDate, LocalDate endDate);
+
+    @Query("""
+        SELECT s
+        FROM SpecificSlot s
+        WHERE s.user = :user
+          AND s.status = :status
+          AND (
+                s.slotDate < :today
+                OR (
+                    s.slotDate = :today
+                    AND s.endTime < :now
+                )
+          )
+    """)
+    List<SpecificSlot> findFinishedSpecificSlotsByUser(User user, SpecificSlotStatus status, LocalDate today, LocalTime now);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/CalendarServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/CalendarServiceImpl.java
@@ -3,8 +3,10 @@ package com.three_tech_solutions.slot_app.services.implementations;
 import com.three_tech_solutions.slot_app.components.calendar_view_builder.factory.CalendarViewFactory;
 import com.three_tech_solutions.slot_app.controllers.responses.CalendarResponse;
 import com.three_tech_solutions.slot_app.data.enums.CalendarViewType;
+import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.models.User;
 import com.three_tech_solutions.slot_app.services.interfaces.CalendarService;
+import com.three_tech_solutions.slot_app.services.interfaces.SpecificSlotService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +17,12 @@ import java.time.LocalDate;
 public class CalendarServiceImpl implements CalendarService {
 
     private final CalendarViewFactory calendarViewFactory;
+    private final SpecificSlotService specificSlotService;
 
     @Override
     public CalendarResponse getUserCalendar(User user, CalendarViewType viewType, LocalDate date) {
+        specificSlotService.finishPastSpecificSlots(user.getSpecificSlots());
+
         return calendarViewFactory
                 .getCalendarViewBuilder(viewType)
                 .getCalendarView(user, date);

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/CalendarServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/CalendarServiceImpl.java
@@ -21,7 +21,7 @@ public class CalendarServiceImpl implements CalendarService {
 
     @Override
     public CalendarResponse getUserCalendar(User user, CalendarViewType viewType, LocalDate date) {
-        specificSlotService.finishPastSpecificSlots(user.getSpecificSlots());
+        specificSlotService.finishUserPastSpecificSlots(user);
 
         return calendarViewFactory
                 .getCalendarViewBuilder(viewType)

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -101,7 +101,7 @@ public class SlotServiceImpl implements SlotService {
         Slot slot = getSlotByIdOrThrowException(slotId);
         validateSlotHasNoStudents(slot);
         deleteFutureSpecificSlotsPhysically(slot);
-        logicallyDeleteSpecificSlots(slot);
+        finishPastSpecificSlots(slot);
         unlinkSpecificSlots(slot);
         slotRepository.delete(slot);
     }
@@ -307,13 +307,8 @@ public class SlotServiceImpl implements SlotService {
         slot.getSpecificSlots().removeAll(toDelete);
     }
 
-    private void logicallyDeleteSpecificSlots(Slot slot) {
+    private void finishPastSpecificSlots(Slot slot) {
         specificSlotService.finishPastSpecificSlots(slot.getSpecificSlots());
-
-        slot.getSpecificSlots()
-                .stream()
-                .filter(specificSlot -> !specificSlot.hasFinished())
-                .forEach(specificSlot -> specificSlot.setStatus(SpecificSlotStatus.DELETED));
     }
 
     private void unlinkSpecificSlots(Slot slot) {

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -5,7 +5,6 @@ import com.three_tech_solutions.slot_app.controllers.requests.UpdateSlotRequest;
 import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotResponse;
 import com.three_tech_solutions.slot_app.controllers.responses.UserSlotsByDayResponse;
-import com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus;
 import com.three_tech_solutions.slot_app.data.mappers.SlotMapper;
 import com.three_tech_solutions.slot_app.data.models.Slot;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -308,7 +308,11 @@ public class SlotServiceImpl implements SlotService {
     }
 
     private void logicallyDeleteSpecificSlots(Slot slot) {
+        specificSlotService.finishPastSpecificSlots(slot.getSpecificSlots());
+
         slot.getSpecificSlots()
+                .stream()
+                .filter(specificSlot -> !specificSlot.hasFinished())
                 .forEach(specificSlot -> specificSlot.setStatus(SpecificSlotStatus.DELETED));
     }
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -14,10 +14,12 @@ import com.three_tech_solutions.slot_app.services.interfaces.StudentService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -80,16 +82,21 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
 
     @Override
     public void finishPastSpecificSlots(List<SpecificSlot> specificSlots) {
-        List<SpecificSlot> specificSlotsToFinish = getSpecificSlotsToFinish(specificSlots);
+        List<SpecificSlot> finishedSlots = specificSlots.stream()
+                .filter(SpecificSlot::finish)
+                .toList();
 
-        if (specificSlotsToFinish.isEmpty()) {
-            return;
+        if (!finishedSlots.isEmpty()) {
+            specificSlotRepository.saveAll(finishedSlots);
         }
+    }
 
-        specificSlotsToFinish
-                .forEach(specificSlot -> specificSlot.setStatus(FINISHED));
+    @Async
+    @Override
+    public void finishUserPastSpecificSlots(User user) {
+        List<SpecificSlot> specificSlotsToFinish = specificSlotRepository.findFinishedSpecificSlotsByUser(user, CREATED, LocalDate.now(), LocalTime.now());
 
-        specificSlotRepository.saveAll(specificSlotsToFinish);
+        finishPastSpecificSlots(specificSlotsToFinish);
     }
 
     private static void validateIfSpecificSlotIsNotAlreadyCanceled(SpecificSlot specificSlot) {
@@ -110,13 +117,5 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
                     specificSlotId
             );
         }
-    }
-
-    private List<SpecificSlot> getSpecificSlotsToFinish(List<SpecificSlot> specificSlots) {
-
-        return specificSlots.stream()
-                .filter(specificSlot -> specificSlot.getStatus() == CREATED)
-                .filter(SpecificSlot::hasFinished)
-                .toList();
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import static com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus.CANCELED;
+import static com.three_tech_solutions.slot_app.data.enums.SpecificSlotStatus.*;
 
 @Slf4j
 @Service
@@ -79,6 +79,20 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
                 .toList();
     }
 
+    @Override
+    public void finishPastSpecificSlots(List<SpecificSlot> specificSlots) {
+        List<SpecificSlot> specificSlotsToFinish = getSpecificSlotsToFinish(specificSlots);
+
+        if (specificSlotsToFinish.isEmpty()) {
+            return;
+        }
+
+        specificSlotsToFinish
+                .forEach(specificSlot -> specificSlot.setStatus(FINISHED));
+
+        specificSlotRepository.saveAll(specificSlotsToFinish);
+    }
+
     private static void validateIfSpecificSlotIsNotAlreadyCanceled(SpecificSlot specificSlot) {
         if (specificSlot.getStatus() == CANCELED) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El turno ya se encuentra cancelado");
@@ -97,5 +111,13 @@ public class SpecificSlotServiceImpl implements SpecificSlotService {
                     specificSlotId
             );
         }
+    }
+
+    private List<SpecificSlot> getSpecificSlotsToFinish(List<SpecificSlot> specificSlots) {
+
+        return specificSlots.stream()
+                .filter(specificSlot -> specificSlot.getStatus() == CREATED)
+                .filter(SpecificSlot::hasFinished)
+                .toList();
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SpecificSlotServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
@@ -22,4 +22,6 @@ public interface SpecificSlotService {
     void deleteSpecificSlots(List<SpecificSlot> specificSlots);
 
     void finishPastSpecificSlots(List<SpecificSlot> specificSlots);
+
+    void finishUserPastSpecificSlots(User user);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SpecificSlotService.java
@@ -20,4 +20,6 @@ public interface SpecificSlotService {
     List<SpecificSlotResponse.Student> getStudentsInSpecificSlot(UUID specificSlotId, String filter);
 
     void deleteSpecificSlots(List<SpecificSlot> specificSlots);
+
+    void finishPastSpecificSlots(List<SpecificSlot> specificSlots);
 }


### PR DESCRIPTION
Antes, al eliminar un Slot, los SpecificSlot históricos quedaban con estado DELETED, aunque en realidad eran clases ya realizadas.Como solución, se agregó el estado FINISHED y se actualizó la lógica para que:
-los SpecificSlot futuros se eliminen físicamente,
-los históricos se mantengan como registro,
-y los turnos ya realizados pasen automáticamente a estado FINISHED al consultar el calendario.

También se eliminó el estado DELETED, ya que dejó de tener sentido con la nueva lógica.

Se tiene un specifics slot que ya pasó (fecha 11/05/2026, siendo hoy 13):
<img width="566" height="75" alt="image" src="https://github.com/user-attachments/assets/247a655f-eb32-4627-8f09-f1f1197ae932" />

Se consulta el calendario:
<img width="479" height="375" alt="image" src="https://github.com/user-attachments/assets/0951956e-a192-467f-b281-1579f27e8da7" />

y se cambia el estado de los specifics slots que ya pasaron, al status Finished:
<img width="561" height="66" alt="image" src="https://github.com/user-attachments/assets/303d784e-e8d3-4389-b2f2-09ff263ff509" />

y al eliminar un slot, se eliminan fisicamente los futuros specifics slot, y se mantienen en base de datos los que se encuentran en estado Finished, como información:
<img width="611" height="279" alt="image" src="https://github.com/user-attachments/assets/498ec450-7176-46c7-a25f-6bfe8cd5eccd" />