### PR TITLE
[FTR][SLOT-297]: send registration notification for a new slot

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/components/notifications/NotificationContentBuilder.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/notifications/NotificationContentBuilder.java
@@ -1,5 +1,6 @@
 package com.three_tech_solutions.slot_app.components.notifications;
 
+import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
 import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.Student;
@@ -7,6 +8,8 @@ import com.three_tech_solutions.slot_app.data.models.Student;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class NotificationContentBuilder {
 
@@ -87,6 +90,7 @@ public class NotificationContentBuilder {
                 specificSlot.getEndTime().format(TIME_FORMATTER)
         );
     }
+
     public static String buildSlotCanceledMessage(Student student, String businessName, LocalDate date, LocalTime startTime, boolean hasRecovery) {
         String recoveryMessage = hasRecovery
                 ? "Se te ha acreditado una clase de recuperación ✅"
@@ -108,6 +112,48 @@ public class NotificationContentBuilder {
                 startTime.format(TIME_FORMATTER),
                 recoveryMessage
         );
+    }
+
+    public static String buildStudentSlotsUpdateMessage(Student student, String businessName, List<StudentSlotResponse> slots) {
+        String slotsDescription = buildSlotsDescription(slots);
+
+        return """
+            Hola %s 👋
+
+            Tus turnos fueron actualizados con éxito en %s 🎉
+
+            🕒 Nuevos turnos asignados:
+            %s
+
+            ¡Te esperamos en clase! 🚲💪
+            """.formatted(
+                student.getName(),
+                businessName,
+                slotsDescription
+        );
+    }
+
+    private static String buildSlotsDescription(List<StudentSlotResponse> slots) {
+        return slots.stream()
+                .map(slot -> String.format(
+                        "- %s de %s a %s hs.",
+                        translateDay(slot.dayOfWeek()),
+                        slot.startTime().format(TIME_FORMATTER),
+                        slot.endTime().format(TIME_FORMATTER)
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String translateDay(java.time.DayOfWeek day) {
+        return switch (day) {
+            case MONDAY -> "Lunes";
+            case TUESDAY -> "Martes";
+            case WEDNESDAY -> "Miércoles";
+            case THURSDAY -> "Jueves";
+            case FRIDAY -> "Viernes";
+            case SATURDAY -> "Sábado";
+            case SUNDAY -> "Domingo";
+        };
     }
 
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/components/notifications/NotificationContentBuilder.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/components/notifications/NotificationContentBuilder.java
@@ -4,6 +4,7 @@ import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotRespon
 import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.Student;
+import com.three_tech_solutions.slot_app.utils.DateUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -137,23 +138,11 @@ public class NotificationContentBuilder {
         return slots.stream()
                 .map(slot -> String.format(
                         "- %s de %s a %s hs.",
-                        translateDay(slot.dayOfWeek()),
+                        DateUtils.translateDay(slot.dayOfWeek()),
                         slot.startTime().format(TIME_FORMATTER),
                         slot.endTime().format(TIME_FORMATTER)
                 ))
                 .collect(Collectors.joining("\n"));
-    }
-
-    private static String translateDay(java.time.DayOfWeek day) {
-        return switch (day) {
-            case MONDAY -> "Lunes";
-            case TUESDAY -> "Martes";
-            case WEDNESDAY -> "Miércoles";
-            case THURSDAY -> "Jueves";
-            case FRIDAY -> "Viernes";
-            case SATURDAY -> "Sábado";
-            case SUNDAY -> "Domingo";
-        };
     }
 
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/data/enums/NotificationType.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/enums/NotificationType.java
@@ -8,7 +8,8 @@ public enum NotificationType {
     MONTHLY_FEE_EXPIRATION("Cuota vencida"),
     RESTORE_PASSWORD("Restablecimiento de contraseña"),
     SLOT_RECOVERY("Recuperación de turno"),
-    SPECIFIC_SLOT_CANCELED("Clase cancelada");
+    SPECIFIC_SLOT_CANCELED("Clase cancelada"),
+    STUDENT_SLOTS_UPDATED("Actualización de turnos");
 
     private final String subject;
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/NotificationServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.three_tech_solutions.slot_app.services.implementations;
 
 import com.three_tech_solutions.slot_app.components.notifications.NotificationContentBuilder;
+import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
 import com.three_tech_solutions.slot_app.data.enums.NotificationType;
 import com.three_tech_solutions.slot_app.data.models.*;
 import com.three_tech_solutions.slot_app.data.repositories.NotificationRepository;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -20,13 +22,6 @@ public class NotificationServiceImpl implements NotificationService {
 
     private final MailSenderService mailSenderService;
     private final NotificationRepository notificationRepository;
-
-    private void send(String to, String message, NotificationType type, User user) {
-        String subject = type.getSubject();
-        String html = EmailUtils.formatEmail(subject, message);
-        mailSenderService.sendHtmlMessage(to, subject, html);
-        saveNotification(message, type, user);
-    }
 
     @Override
     public void notifyRestorePassword(String email, String username, String code) {
@@ -60,6 +55,18 @@ public class NotificationServiceImpl implements NotificationService {
         send(student.getEmail(), message, NotificationType.SPECIFIC_SLOT_CANCELED, student.getUser());
     }
 
+    @Override
+    public void notifyStudentSlotsUpdated(Student student, List<StudentSlotResponse> slots) {
+        String message = NotificationContentBuilder.buildStudentSlotsUpdateMessage(student, student.getUser().getBusinessName(), slots);
+        send(student.getEmail(), message, NotificationType.STUDENT_SLOTS_UPDATED, student.getUser());
+    }
+
+    private void send(String to, String message, NotificationType type, User user) {
+        String subject = type.getSubject();
+        String html = EmailUtils.formatEmail(subject, message);
+        mailSenderService.sendHtmlMessage(to, subject, html);
+        saveNotification(message, type, user);
+    }
     private void saveNotification(String message, NotificationType type, User user) {
 
         Notification notification = new Notification();

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/SlotServiceImpl.java
@@ -151,6 +151,14 @@ public class SlotServiceImpl implements SlotService {
         user.getSlots().forEach(slot -> slot.setCapacity(newCapacity));
     }
 
+    @Override
+    public List<StudentSlotResponse> getSlotsByIds(List<UUID> slotIds) {
+        return slotRepository.findAllById(slotIds)
+                .stream()
+                .map(slotMapper::toStudentSlotResponse)
+                .toList();
+    }
+
     private boolean exceedsCapacity(SpecificSlot specificSlot, byte newCapacity) {
         int slotUsedCapacity = calculateUsedCapacity(specificSlot.getSlot());
         int specificSlotUsedCapacity = specificSlot.getSpecificSlotUsedCapacity();

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -179,9 +179,14 @@ public class StudentServiceImpl implements StudentService {
                     removePaymentDayIfNewPlanIsBeginningOfMonth(request);
                     studentMapper.updateStudent(student,request, getPlanByIdOrThrowException(request.getPlanId()));
                     validateStudentSlotAssignment(request.getSlotIds(), request.getPlanId());
-                    slotService.updateSlotsForStudent(request.getSlotIds(), student);
+                    List<StudentSlotResponse> requestedSlots = slotService.getSlotsByIds(request.getSlotIds());
+
+                    if (!previousSlots.equals(requestedSlots)) {
+                        slotService.updateSlotsForStudent(request.getSlotIds(), student);
+                        notifyStudentSlotsUpdated(student, requestedSlots);
+                    }
+
                     Student updatedStudent = studentRepository.save(student);
-                    notifyIfStudentSlotsChanged(updatedStudent, previousSlots);
                     return studentMapper.toStudentResponse(updatedStudent);
                 })
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "El estudiante no existe."));
@@ -462,15 +467,11 @@ public class StudentServiceImpl implements StudentService {
         }
     }
 
-    private void notifyIfStudentSlotsChanged(Student updatedStudent, List<StudentSlotResponse> previousSlots) {
-        List<StudentSlotResponse> updatedSlots = slotService.getSlotsByStudent(updatedStudent);
-
-        if (!previousSlots.equals(updatedSlots)) {
-            try {
-                notificationService.notifyStudentSlotsUpdated(updatedStudent, updatedSlots);
-            } catch (Exception e) {
-                log.error("Error notificando cambio de turnos del estudiante {}", updatedStudent.getId(), e);
-            }
+    private void notifyStudentSlotsUpdated(Student student, List<StudentSlotResponse> updatedSlots) {
+        try {
+            notificationService.notifyStudentSlotsUpdated(student, updatedSlots);
+        } catch (Exception e) {
+            log.error("Error notificando cambio de turnos del estudiante {}", student.getId(), e);
         }
     }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -175,12 +175,14 @@ public class StudentServiceImpl implements StudentService {
         validatePaymentDay(request.getPaymentPlanName(), request.getPaymentDay());
         return studentRepository.findById(studentId)
                 .map(student -> {
+                    List<StudentSlotResponse> previousSlots = slotService.getSlotsByStudent(student);
                     removePaymentDayIfNewPlanIsBeginningOfMonth(request);
                     studentMapper.updateStudent(student,request, getPlanByIdOrThrowException(request.getPlanId()));
                     validateStudentSlotAssignment(request.getSlotIds(), request.getPlanId());
                     slotService.updateSlotsForStudent(request.getSlotIds(), student);
-
-                    return studentMapper.toStudentResponse(studentRepository.save(student));
+                    Student updatedStudent = studentRepository.save(student);
+                    notifyIfStudentSlotsChanged(updatedStudent, previousSlots);
+                    return studentMapper.toStudentResponse(updatedStudent);
                 })
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "El estudiante no existe."));
     }
@@ -460,4 +462,15 @@ public class StudentServiceImpl implements StudentService {
         }
     }
 
+    private void notifyIfStudentSlotsChanged(Student updatedStudent, List<StudentSlotResponse> previousSlots) {
+        List<StudentSlotResponse> updatedSlots = slotService.getSlotsByStudent(updatedStudent);
+
+        if (!previousSlots.equals(updatedSlots)) {
+            try {
+                notificationService.notifyStudentSlotsUpdated(updatedStudent, updatedSlots);
+            } catch (Exception e) {
+                log.error("Error notificando cambio de turnos del estudiante {}", updatedStudent.getId(), e);
+            }
+        }
+    }
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/NotificationService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/NotificationService.java
@@ -1,11 +1,13 @@
 package com.three_tech_solutions.slot_app.services.interfaces;
 
+import com.three_tech_solutions.slot_app.controllers.responses.StudentSlotResponse;
 import com.three_tech_solutions.slot_app.data.models.MonthlyFee;
 import com.three_tech_solutions.slot_app.data.models.SpecificSlot;
 import com.three_tech_solutions.slot_app.data.models.Student;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface NotificationService {
 
@@ -18,4 +20,6 @@ public interface NotificationService {
     void notifySlotRecovery(Student student, SpecificSlot specificSlot);
 
     void notifySlotCanceled(Student student, LocalDate date, LocalTime startTime, boolean hasRecovery);
+
+    void notifyStudentSlotsUpdated(Student student, List<StudentSlotResponse> slots);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/interfaces/SlotService.java
@@ -35,4 +35,6 @@ public interface SlotService {
     void removeStudentFromAllSlots(Student student);
 
     void updateSlotsAndSpecificSlotsCapacity(User user, byte newCapacity);
+
+    List<StudentSlotResponse> getSlotsByIds(List<UUID> slotIds);
 }

--- a/src/main/java/com/three_tech_solutions/slot_app/utils/DateUtils.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/utils/DateUtils.java
@@ -16,4 +16,16 @@ public class DateUtils {
     public static LocalDate getNextDateWithSameDayOfWeek(LocalDate date) {
         return date.with(TemporalAdjusters.next(date.getDayOfWeek()));
     }
+
+    public static String translateDay(DayOfWeek day) {
+        return switch (day) {
+            case MONDAY -> "Lunes";
+            case TUESDAY -> "Martes";
+            case WEDNESDAY -> "Miércoles";
+            case THURSDAY -> "Jueves";
+            case FRIDAY -> "Viernes";
+            case SATURDAY -> "Sábado";
+            case SUNDAY -> "Domingo";
+        };
+    }
 }


### PR DESCRIPTION
Enviar notificación de registro en un turno nuevo

Al hacer las otras tareas de notificación, los casos de alta de un alumno nuevo y reactivación ya notificaban los turnos asignados, así que esos escenarios ya están cubiertos. Por eso, en esta tarea se implementó únicamente el caso donde un alumno cambia sus turnos desde la actualización de datos.
También se agregó una validación para que la notificación se envíe solo cuando realmente cambian los turnos. Si se actualiza otra información del alumno (como plan de pago, día de pago u otros datos) pero los turnos siguen siendo los mismos, no se envía la notificación.
<img width="507" height="397" alt="image" src="https://github.com/user-attachments/assets/5323809f-13ce-4eb1-8323-7e39bd4ebf94" />

