### PR TITLE
[FIX][SLOT-310]: se agrega fix para el filtrado por la situacion

### DIFF
--- a/src/main/java/com/three_tech_solutions/slot_app/data/repositories/StudentRepository.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/data/repositories/StudentRepository.java
@@ -26,6 +26,27 @@ public interface StudentRepository extends JpaRepository<Student, UUID> {
            AND (:filterByAbsences = false OR EXISTS (
                    SELECT a FROM Absence a WHERE a.student = s AND a.status = 'PENDING'
            ))
+           AND (
+            :withDebt IS NULL
+            OR (
+                :withDebt = true
+                AND EXISTS (
+                    SELECT mf
+                    FROM MonthlyFee mf
+                    WHERE mf.student = s
+                      AND mf.currentStatus = 'OUT_OF_TIME'
+                )
+            )
+            OR (
+                :withDebt = false
+                AND NOT EXISTS (
+                    SELECT mf
+                    FROM MonthlyFee mf
+                    WHERE mf.student = s
+                      AND mf.currentStatus = 'OUT_OF_TIME'
+                )
+            )
+        )
         ORDER BY s.enabled DESC
     """)
     Page<Student> getStudentsByUserAndFilters(
@@ -33,6 +54,7 @@ public interface StudentRepository extends JpaRepository<Student, UUID> {
             @Param("filter") String filter,
             @Param("filterByAbsences") boolean filterByAbsences,
             @Param("isActive") Boolean isActive,
+            @Param("withDebt") Boolean withDebt,
             Pageable pageable
     );
 

--- a/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
+++ b/src/main/java/com/three_tech_solutions/slot_app/services/implementations/StudentServiceImpl.java
@@ -19,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -193,32 +191,17 @@ public class StudentServiceImpl implements StudentService {
 
     @Override
     public Page<StudentResponse> getStudentsByUserAndNameAndLastNameAndDni(User user, String filters, boolean filterByAbsences, StudentSituation status, Boolean isActive, Pageable pageable) {
-        Page<StudentResponse> studentsPage = studentRepository
-                .getStudentsByUserAndFilters(user, filters, filterByAbsences, isActive, pageable)
+        return studentRepository
+                .getStudentsByUserAndFilters(user, filters, filterByAbsences, isActive, getStudentSituationFilter(status), pageable)
                 .map(studentMapper::toStudentResponse);
-        List<StudentResponse> filteredContent = getContentByStudentSituationFilter(status, studentsPage);
-
-        return new PageImpl<>(
-                filteredContent,
-                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
-                getContentSize(status, studentsPage, filteredContent)
-        );
     }
 
-    private static long getContentSize(StudentSituation status, Page<StudentResponse> studentsPage, List<StudentResponse> filteredContent) {
-        // This is because when we apply the student situation filter,
-        // we are filtering the content of the page, but the total elements of the page
-        // still corresponds to the total elements without applying the student situation filter.
-        // So we need to adjust the total elements of the page to correspond to the filtered content size.
-        return status == null ? studentsPage.getTotalElements() : filteredContent.size();
-    }
-
-    private static List<StudentResponse> getContentByStudentSituationFilter(StudentSituation status, Page<StudentResponse> studentsPage) {
-        return status != null ? filterStudentPageBySituationFilter(status, studentsPage) : studentsPage.getContent();
-    }
-
-    private static List<StudentResponse> filterStudentPageBySituationFilter(StudentSituation status, Page<StudentResponse> studentsPage) {
-        return studentsPage.getContent().stream().filter(studentResponse -> studentResponse.status().equals(status)).toList();
+    private static Boolean getStudentSituationFilter(StudentSituation status) {
+        if (status == null) {
+            return null;
+        } else {
+            return StudentSituation.CON_DEUDA.equals(status);
+        }
     }
 
     @Override
@@ -466,5 +449,4 @@ public class StudentServiceImpl implements StudentService {
             );
         }
     }
-
 }


### PR DESCRIPTION
Se modifica la logica del endpoint aprovechando el currentStatus de las cuotas para arreglar el filtrado que teniamos en memoria ahora lo hacemos por BBDD directamente.

# Ejemplos con el front

## Usuarios creados
<img width="3286" height="1034" alt="image" src="https://github.com/user-attachments/assets/b7f6bc0d-50f8-42de-ae88-30a203bc5949" />
<img width="3345" height="1070" alt="image" src="https://github.com/user-attachments/assets/cc74a5ab-29af-4699-bec8-151f72cd1682" />

## Filtro con deuda activo
<img width="3330" height="1059" alt="image" src="https://github.com/user-attachments/assets/14e5e7f6-b20b-41ee-9d38-dc41662c4a2d" />
<img width="3292" height="1055" alt="image" src="https://github.com/user-attachments/assets/405cc6a8-d522-4c7e-ab17-d702b541f1f8" />

## Filtro en termino activo
<img width="3288" height="1048" alt="image" src="https://github.com/user-attachments/assets/4749e895-21b3-44cc-bed7-ed56a410ca9e" />

## Previo al fix

Aca es utilizando dev asi que los estudiantes son distintos

<img width="3315" height="759" alt="image" src="https://github.com/user-attachments/assets/425c6062-8940-4ca8-a67b-149fc18cc994" />
<img width="3326" height="542" alt="image" src="https://github.com/user-attachments/assets/46bff333-9953-47d8-9cfe-7c82f1167413" />
<img width="3295" height="1053" alt="image" src="https://github.com/user-attachments/assets/0009fc4a-6db2-47e6-969f-bfa5f9f9515a" />

